### PR TITLE
Resolve #73; Use a div to display image instead of h1.

### DIFF
--- a/app/views/user_mailer/notify_collection_analyzed.html.erb
+++ b/app/views/user_mailer/notify_collection_analyzed.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
     <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; text-align: center;' -%>
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; width: auto;' -%>
     </div>
   </head>
   <body>

--- a/app/views/user_mailer/notify_collection_analyzed.html.erb
+++ b/app/views/user_mailer/notify_collection_analyzed.html.erb
@@ -5,9 +5,9 @@
   </head>
   <body>
   <body>
-    <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
+    <div style="background-color:LightGray; width: 100%; margin: auto;">
       <p style="text-align: center;">
-        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: inline-block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px;' -%>
       </p>
     </div>
     <p>Hi <%= @user.name %>,</p>

--- a/app/views/user_mailer/notify_collection_analyzed.html.erb
+++ b/app/views/user_mailer/notify_collection_analyzed.html.erb
@@ -2,11 +2,12 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; width: auto;' -%>
-    </div>
   </head>
   <body>
+  <body>
+    <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+    </div>
     <p>Hi <%= @user.name %>,</p>
     <p>Your Archives Unleashed Cloud job has finished,
     and is available at: <%= link_to(user_collection_url(@user, @collection), user_collection_url(@user, @collection)) %><br>
@@ -14,7 +15,7 @@
     <p>Thanks for using the Archives Unleashed Cloud, and have a great day!</p>
   </body>
   </br>
-  <footer style="background-color:LightGray; text-align: center;">
+  <footer style="background-color:LightGray; text-align: center; padding-top: 5px; padding-bottom: 5px;">
       <p>
         <a href="http://archivesunleashed.org">archivesunleashed.org</a> | 
         <a href="https://twitter.com/unleasharchives">@unleasharchives</a> | 

--- a/app/views/user_mailer/notify_collection_analyzed.html.erb
+++ b/app/views/user_mailer/notify_collection_analyzed.html.erb
@@ -6,7 +6,9 @@
   <body>
   <body>
     <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+      <p style="text-align: center;">
+        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+      </p>
     </div>
     <p>Hi <%= @user.name %>,</p>
     <p>Your Archives Unleashed Cloud job has finished,

--- a/app/views/user_mailer/notify_collection_analyzed.html.erb
+++ b/app/views/user_mailer/notify_collection_analyzed.html.erb
@@ -2,9 +2,9 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <h1 style="background-color:LightGray; text-align:center; color:black; font-family:helvetica; display=inline-block; ">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo' -%><br/><br/>
-  </h1>
+    <div style="background-color:LightGray; width: 100%; margin: auto;">
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px;' -%>
+    </div>
   </head>
   <body>
     <p>Hi <%= @user.name %>,</p>

--- a/app/views/user_mailer/notify_collection_analyzed.html.erb
+++ b/app/views/user_mailer/notify_collection_analyzed.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
     <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px;' -%>
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; text-align: center;' -%>
     </div>
   </head>
   <body>

--- a/app/views/user_mailer/notify_collection_downloaded.html.erb
+++ b/app/views/user_mailer/notify_collection_downloaded.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
     <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; text-align: center;' -%>
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; width: auto;' -%>
     </div>
   </head>
   <body>

--- a/app/views/user_mailer/notify_collection_downloaded.html.erb
+++ b/app/views/user_mailer/notify_collection_downloaded.html.erb
@@ -2,11 +2,12 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; width: auto;' -%>
-    </div>
   </head>
   <body>
+  <body>
+    <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+    </div>
     <p>Hi <%= @user.name %>,</p>
     <p>
       The <%= @collection.title %> collection has been downloaded, and analysis will now begin. Look out for another email from us soon!<br>
@@ -14,7 +15,7 @@
     <p>Thanks for using the Archives Unleashed Cloud, and have a great day!</p>
   </body>
   </br>
-  <footer style="background-color:LightGray; text-align: center;">
+  <footer style="background-color:LightGray; text-align: center; padding-top: 5px; padding-bottom: 5px;">
       <p>
         <a href="http://archivesunleashed.org">archivesunleashed.org</a> | 
         <a href="https://twitter.com/unleasharchives">@unleasharchives</a> | 

--- a/app/views/user_mailer/notify_collection_downloaded.html.erb
+++ b/app/views/user_mailer/notify_collection_downloaded.html.erb
@@ -5,9 +5,9 @@
   </head>
   <body>
   <body>
-    <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
+    <div style="background-color:LightGray; width: 100%; margin: auto;">
       <p style="text-align: center;">
-        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: inline-block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px;' -%>
       </p>
     </div>
     <p>Hi <%= @user.name %>,</p>

--- a/app/views/user_mailer/notify_collection_downloaded.html.erb
+++ b/app/views/user_mailer/notify_collection_downloaded.html.erb
@@ -6,7 +6,9 @@
   <body>
   <body>
     <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+      <p style="text-align: center;">
+        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+      </p>
     </div>
     <p>Hi <%= @user.name %>,</p>
     <p>

--- a/app/views/user_mailer/notify_collection_downloaded.html.erb
+++ b/app/views/user_mailer/notify_collection_downloaded.html.erb
@@ -2,9 +2,9 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <h1 style="background-color:LightGray; text-align:center; color:black; font-family:helvetica; display=inline-block; ">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo' -%><br/><br/>
-    </h1>
+    <div style="background-color:LightGray; width: 100%; margin: auto;">
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px;' -%>
+    </div>
   </head>
   <body>
     <p>Hi <%= @user.name %>,</p>

--- a/app/views/user_mailer/notify_collection_downloaded.html.erb
+++ b/app/views/user_mailer/notify_collection_downloaded.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
     <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px;' -%>
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; text-align: center;' -%>
     </div>
   </head>
   <body>

--- a/app/views/user_mailer/notify_collection_setup.html.erb
+++ b/app/views/user_mailer/notify_collection_setup.html.erb
@@ -5,7 +5,9 @@
   </head>
   <body>
     <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+      <p style="text-align: center;">
+        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+      </p>
     </div>
     <p>Hi <%= @user.name %>,</p>
     <p>

--- a/app/views/user_mailer/notify_collection_setup.html.erb
+++ b/app/views/user_mailer/notify_collection_setup.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
     <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; text-align: center;' -%>
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; width: auto;' -%>
     </div>
   </head>
   <body>

--- a/app/views/user_mailer/notify_collection_setup.html.erb
+++ b/app/views/user_mailer/notify_collection_setup.html.erb
@@ -2,9 +2,9 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <h1 style="background-color:LightGray; text-align:center; color:black; font-family:helvetica; display=inline-block; ">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo' -%><br/><br/>
-    </h1>
+    <div style="background-color:LightGray; width: 100%; margin: auto;">
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px;' -%>
+    </div>
   </head>
   <body>
     <p>Hi <%= @user.name %>,</p>

--- a/app/views/user_mailer/notify_collection_setup.html.erb
+++ b/app/views/user_mailer/notify_collection_setup.html.erb
@@ -2,11 +2,11 @@
 <html>
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
-    <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; width: auto;' -%>
-    </div>
   </head>
   <body>
+    <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+    </div>
     <p>Hi <%= @user.name %>,</p>
     <p>
       Your Archives Unleashed Cloud collections are now setup,
@@ -15,7 +15,7 @@
     <p>Thanks for using the Archives Unleashed Cloud, and have a great day!</p>
   </body>
   </br>
-  <footer style="background-color:LightGray; text-align: center;">
+  <footer style="background-color:LightGray; text-align: center; padding-top: 5px; padding-bottom: 5px;">
       <p>
         <a href="http://archivesunleashed.org">archivesunleashed.org</a> | 
         <a href="https://twitter.com/unleasharchives">@unleasharchives</a> | 

--- a/app/views/user_mailer/notify_collection_setup.html.erb
+++ b/app/views/user_mailer/notify_collection_setup.html.erb
@@ -4,9 +4,9 @@
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
   </head>
   <body>
-    <div style="background-color:LightGray; width: 100%; margin: auto; text-align:center;">
+    <div style="background-color:LightGray; width: 100%; margin: auto;">
       <p style="text-align: center;">
-        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px; width: auto;' -%>
+        <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', style: 'display: inline-block; margin-left: auto; margin-right: auto; padding-top: 30px; padding-bottom: 30px;' -%>
       </p>
     </div>
     <p>Hi <%= @user.name %>,</p>

--- a/app/views/user_mailer/notify_collection_setup.html.erb
+++ b/app/views/user_mailer/notify_collection_setup.html.erb
@@ -3,7 +3,7 @@
   <head>
     <meta content='text/html; charset=UTF-8' http-equiv='Content-Type' />
     <div style="background-color:LightGray; width: 100%; margin: auto;">
-      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px;' -%>
+      <%= image_tag attachments['AUK-Logo-full.png'].url, alt: 'Archives Unleashed Logo', class: 'photo', style: 'display: block; margin-left: auto; margin-right: auto; padding-top: 50px; padding-bottom: 50px; text-align: center;' -%>
     </div>
   </head>
   <body>


### PR DESCRIPTION
@ianmilligan1 can you test this one out? It _should_ work in all three.
 
![screenshot_20180318-125020_gmail](https://user-images.githubusercontent.com/218561/37568453-b0c9c0fa-2aab-11e8-9422-d7e31f861359.jpg)
![screenshot from 2018-03-18 12-51-36](https://user-images.githubusercontent.com/218561/37568455-b804ac04-2aab-11e8-9d8d-451c73bac2e3.png)
![screenshot from 2018-03-18 12-51-08](https://user-images.githubusercontent.com/218561/37568456-b8137f68-2aab-11e8-8702-4d80dcca840b.png)

We can also bump down the padding on the top and bottom from `50px;` to `25px` if you want.

Also, this will probably finally trigger code cov really being run since this PR is coming from an actual fork, and we'll probably finally show the awful coverage.