### PR TITLE
Adds contact information to about page

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -59,6 +59,6 @@
     <p class="about_p">Other financial and in-kind support comes from the <a href="http://www.sshrc-crsh.gc.ca" target="_blank">Social Sciences and Humanities Research Council</a>, <a href="https://www.computecanada.ca" target="_blank">Compute Canada</a>, the <a href="https://www.ontario.ca/page/ministry-research-innovation-and-science" target="_blank">Ontario Ministry of Research, Innovation, and Science</a>, and <a href="http://www.startsmartlabs.com" target="_blank">Start Smart Labs</a>.</p>
   <h3 class=about_h3>How can I contact the AUK team?</h3>
     <p class="about_p">Join our <a href="https://docs.google.com/forms/d/e/1FAIpQLScXPIH0Ssw63yWqyMkUqHVYmz2-ItBMzHiJQ-sOlJwTA8u5AQ/viewform?usp=sf_link">Slack team</a> if you want to see how things are developing, to discuss suggestions or other parts of our project, or to just shoot the breeze about all things web archiving. You can also follow us on <a href="https://twitter.com/unleass">Twitter!</a></p>
-    <p class="about_p">Alternatively, please just drop us a line via e-mail at <a href="mailto:archivesunleashed@gmail.com">archivesunleashed@gmail.com</a>.
+    <p class="about_p">Alternatively, please just drop us a line via e-mail at <a href="mailto:archivesunleashed@gmail.com">archivesunleashed@gmail.com</a>.</p>
 </div>
 <% end %>

--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -57,5 +57,8 @@
   <h3 class=about_h3>Who funds the Archives Unleashed Cloud?</h3>
     <p class="about_p">This work is primarily supported by the <a href="https://mellon.org/" target="_blank"> Andrew W. Mellon Foundation</a>, the <a href="http://uwaterloo.ca" target="_blank">University of Waterloo</a>, and <a href="https://www.library.yorku.ca/web/" target="_blank">York University Libraries</a>.</p>
     <p class="about_p">Other financial and in-kind support comes from the <a href="http://www.sshrc-crsh.gc.ca" target="_blank">Social Sciences and Humanities Research Council</a>, <a href="https://www.computecanada.ca" target="_blank">Compute Canada</a>, the <a href="https://www.ontario.ca/page/ministry-research-innovation-and-science" target="_blank">Ontario Ministry of Research, Innovation, and Science</a>, and <a href="http://www.startsmartlabs.com" target="_blank">Start Smart Labs</a>.</p>
+  <h3 class=about_h3>How can I contact the AUK team?</h3>
+    <p class="about_p">Join our <a href="https://docs.google.com/forms/d/e/1FAIpQLScXPIH0Ssw63yWqyMkUqHVYmz2-ItBMzHiJQ-sOlJwTA8u5AQ/viewform?usp=sf_link">Slack team</a> if you want to see how things are developing, to discuss suggestions or other parts of our project, or to just shoot the breeze about all things web archiving. You can also follow us on <a href="https://twitter.com/unleass">Twitter!</a></p>
+    <p class="about_p">Alternatively, please just drop us a line via e-mail at <a href="mailto:archivesunleashed@gmail.com">archivesunleashed@gmail.com</a>.
 </div>
 <% end %>


### PR DESCRIPTION
I realized that our "about" page didn't have contact information, and that's often something I'm looking for when I want to engage with a project!

I have cribbed from our own project page (which has the benefit of keeping Sam's voice on the page, which I think strikes the right balance between professional and boring 😄 ). Screenshot below:

![screen shot 2018-04-12 at 4 38 39 pm](https://user-images.githubusercontent.com/3834704/38702991-1005bb50-3e70-11e8-9910-b7a06235d7c4.png)

Feel free to edit. I wasn't sure about the positioning, but generally I think contact should be at top or bottom.