### PR TITLE
Collect GEXF data from file instead of HTML-DOM - issue-194

### DIFF
--- a/app/assets/javascripts/graphs.js
+++ b/app/assets/javascripts/graphs.js
@@ -8,8 +8,6 @@ function createGraph(data, instance) {
       minNodeSize: 1,
       minArrowSize: 5
     });
-      // We first need to save the original colors of our
-      // nodes and edges, like this:
     instance.graph.nodes().forEach(function (n) {
       n.originalColor = n.color;
     });
@@ -32,7 +30,7 @@ function createGraph(data, instance) {
 }
 
 function graphRender(instance) {
-  var gexfUrl = $('#graph-modal').data('gexf_url'); // eslint-disable-line vars-on-top;
+  var gexfUrl = $('#graph-modal').data('gexf_url');
   createGraph(gexfUrl, instance);
 }
 

--- a/app/assets/javascripts/graphs.js
+++ b/app/assets/javascripts/graphs.js
@@ -1,46 +1,39 @@
 function createGraph(data, instance) {
-  if (data !== '') {
-    data = $.parseXML(data); // eslint-disable-line no-param-reassign
-    sigma.parsers.gexf(data, instance, function (y) { // eslint-disable-line no-unused-vars
-      instance.settings({
-        nodeColor: 'default',
-        edgeColor: 'default',
-        defaultEdgeType: 'arrow',
-        labelThreshold: 7,
-        minNodeSize: 1,
-        minArrowSize: 5
-      });
+  sigma.parsers.gexf(data, instance, function (y) { // eslint-disable-line no-unused-vars
+    instance.settings({
+      nodeColor: 'default',
+      edgeColor: 'default',
+      defaultEdgeType: 'arrow',
+      labelThreshold: 7,
+      minNodeSize: 1,
+      minArrowSize: 5
+    });
       // We first need to save the original colors of our
       // nodes and edges, like this:
-      instance.graph.nodes().forEach(function (n) {
-        n.originalColor = n.color;
-      });
-      instance.graph.edges().forEach(function (e) {
-        e.originalColor = e.color;
-      });
-      if (instance.graph.nodes().length === 0) {
-        instance.graph.addNode({
-          id: 'empty',
-          label: '(This graph is empty.)',
-          x: 10,
-          y: 10,
-          size: 10,
-          color: '#999'
-        });
-      }
+    instance.graph.nodes().forEach(function (n) {
+      n.originalColor = n.color;
     });
+    instance.graph.edges().forEach(function (e) {
+      e.originalColor = e.color;
+    });
+    if (instance.graph.nodes().length === 0) {
+      instance.graph.addNode({
+        id: 'empty',
+        label: '(This graph is empty.)',
+        x: 10,
+        y: 10,
+        size: 10,
+        color: '#999'
+      });
+    }
     instance.renderers[0].resize();
     instance.refresh();
-  } else {
-    $('#graph').append('Cannot find Gexf file');
-  }
+  });
 }
 
 function graphRender(instance) {
-  if (typeof $('#graph-modal').data('gexf') !== 'undefined') {
-    var gexfFileData = $('#graph-modal').data('gexf'); // eslint-disable-line vars-on-top
-    createGraph(gexfFileData, instance);
-  }
+  var gexfUrl = $('#graph-modal').data('gexf_url'); // eslint-disable-line vars-on-top;
+  createGraph(gexfUrl, instance);
 }
 
 function increment(state) {

--- a/app/helpers/collections_helper.rb
+++ b/app/helpers/collections_helper.rb
@@ -21,20 +21,6 @@ module CollectionsHelper
     end
   end
 
-  def display_gexf(user_id, collection_id, account)
-    collection_path = ENV['DOWNLOAD_PATH'] +
-                      '/' + account.to_s +
-                      '/' + collection_id.to_s + '/'
-    gexf_file = collection_path + user_id.to_s +
-                '/derivatives/gephi/' + collection_id.to_s +
-                '-gephi.gexf'
-    # use Nokogiri to confirm proper XML document?
-    if File.exist?(gexf_file)
-      render plain: safe_join([File.read(gexf_file).html_safe]),
-             content_type: 'application/xml'
-    end
-  end
-
   def gexf_path(user_id, collection_id, account)
     collection_path = ENV['DOWNLOAD_PATH'] +
                       '/' + account.to_s +

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -40,7 +40,6 @@
     <main class="col-sm-9 col-md-10">
     <h1><%= @collection.title %></h1>
       <p><%= button_to("Analyze Collection", user_collection_download_path(@user, @collection), data: {confirm: "Download and analyze " + collection_size_human(@collection.id, @user) + "? \n\nDownloading large collections can take a long time depending on our connection to the Internet Archive, and the number of other users who are currently using the service. We ask for your patience."}, class: 'btn btn-primary btn-lg btn-block') %></p>
-      <% unless display_gexf(@user.id, @collection.id, @collection.account).blank? %>
         <h2>Hyperlink Diagram</h2>
         <div id="graph-wrapper">
           <span id="modal-click" data-toggle="modal" data-target="#sigma-fullscreen">
@@ -65,9 +64,8 @@
           <div id="graph"></div>
         </div>
         <%= javascript_tag do %>
-          $("#graph-modal").data("gexf", `<%= display_gexf(@user.id, @collection.id, @collection.account) %>`);
+          $("#graph-modal").data("gexf_url", `<%= 'http://' + ENV['BASE_HOSTNAME'] + user_collection_download_gexf_path(@user.id, @collection.id, @collection.account) %>`);
         <% end %>
-      <% end %>
       <% unless !File.exists? domains_path(@user.id, @collection.id, @collection.account) %>
         <h2>Download Collection Derivatives</h2>
         <div class="text-center">

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -40,7 +40,7 @@
     <main class="col-sm-9 col-md-10">
     <h1><%= @collection.title %></h1>
       <p><%= button_to("Analyze Collection", user_collection_download_path(@user, @collection), data: {confirm: "Download and analyze " + collection_size_human(@collection.id, @user) + "? \n\nDownloading large collections can take a long time depending on our connection to the Internet Archive, and the number of other users who are currently using the service. We ask for your patience."}, class: 'btn btn-primary btn-lg btn-block') %></p>
-      <% unless gexf_path(@user.id, @collection.id, @collection.account).blank? %>
+      <% unless !File.exists? gexf_path(@user.id, @collection.id, @collection.account) %>
         <h2>Hyperlink Diagram</h2>
         <div id="graph-wrapper">
           <span id="modal-click" data-toggle="modal" data-target="#sigma-fullscreen">

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -40,7 +40,7 @@
     <main class="col-sm-9 col-md-10">
     <h1><%= @collection.title %></h1>
       <p><%= button_to("Analyze Collection", user_collection_download_path(@user, @collection), data: {confirm: "Download and analyze " + collection_size_human(@collection.id, @user) + "? \n\nDownloading large collections can take a long time depending on our connection to the Internet Archive, and the number of other users who are currently using the service. We ask for your patience."}, class: 'btn btn-primary btn-lg btn-block') %></p>
-      <%= unless gexf_path(@user.id, @collection.id, @collection.account).blank? %>
+      <% unless gexf_path(@user.id, @collection.id, @collection.account).blank? %>
         <h2>Hyperlink Diagram</h2>
         <div id="graph-wrapper">
           <span id="modal-click" data-toggle="modal" data-target="#sigma-fullscreen">

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -40,6 +40,7 @@
     <main class="col-sm-9 col-md-10">
     <h1><%= @collection.title %></h1>
       <p><%= button_to("Analyze Collection", user_collection_download_path(@user, @collection), data: {confirm: "Download and analyze " + collection_size_human(@collection.id, @user) + "? \n\nDownloading large collections can take a long time depending on our connection to the Internet Archive, and the number of other users who are currently using the service. We ask for your patience."}, class: 'btn btn-primary btn-lg btn-block') %></p>
+      <%= unless gexf_path(@user.id, @collection.id, @collection.account).blank? %>
         <h2>Hyperlink Diagram</h2>
         <div id="graph-wrapper">
           <span id="modal-click" data-toggle="modal" data-target="#sigma-fullscreen">
@@ -64,8 +65,9 @@
           <div id="graph"></div>
         </div>
         <%= javascript_tag do %>
-          $("#graph-modal").data("gexf_url", `<%= 'http://' + ENV['BASE_HOSTNAME'] + user_collection_download_gexf_path(@user.id, @collection.id, @collection.account) %>`);
+          $("#graph-modal").data("gexf_url", `<%= ENV['BASE_HOST_URL'] + user_collection_download_gexf_path(@user.id, @collection.id, @collection.account) %>`);
         <% end %>
+      <% end %>
       <% unless !File.exists? domains_path(@user.id, @collection.id, @collection.account) %>
         <h2>Download Collection Derivatives</h2>
         <div class="text-center">


### PR DESCRIPTION
**GitHub issue(s)**:

- #194 
- see also
  - #189 
  - #191

# What does this Pull Request do?

Extracts gexf data from a url instead of current approach which required putting data into the html-DOM.  The previous approach duplicated accessing the data file.

- remove gexf call in collection helper
- revise graph.js to call from url.
- revise view to put url instead of data into DOM

# How should this be tested?

AUK should work almost exactly as before, except perhaps faster. Large files should load the page before doing any 'potato'ing' of the browser.

# Additional Notes:
Resolves #194.
May improve responsiveness to larger files as per problems mentioned in #189 or #191.

# Interested parties

@ianmilligan1 
