### PR TITLE
Fixes accordion display for guides, resolves #207

### DIFF
--- a/app/views/pages/derivatives.html.erb
+++ b/app/views/pages/derivatives.html.erb
@@ -70,7 +70,7 @@
           </div>
         </div>
       </div>
-      <div class="auk_deriv_accord card">
+      <div class="auk_deriv_accord card" id="accordion">
         <div class="auk_deriv_accord-header card-header" id="headingTwo">
           <h5 class="mb-0">
             <button class="btn btn-link collapsed" data-toggle="collapse" data-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">


### PR DESCRIPTION
**GitHub issue(s)**:

#207 

# What does this Pull Request do?

As noted in #207, there was a change with Bootstrap 4.1 that slightly changed how accordions work. I diffed the 4.0 and 4.1 guides, and looks like they are slightly stricter on setting `data-parents` now. I just had to tweak the code slightly.

# How should this be tested?

You should build this locally and be able to use the sliders at http://localhost:3000/derivatives. i.e. so it again looks like:

![screen shot 2018-11-09 at 2 31 01 pm](https://user-images.githubusercontent.com/3834704/48283959-1661c400-e42c-11e8-828c-299b8d009aaf.png)

# Additional Notes:

This should be straightforward.

# Interested parties

@SamFritz @ruebot 

Thanks in advance for your help with the Archives Unleashed Toolkit!