### PR TITLE
Adds note about Safari, resolves #206

### DIFF
--- a/app/views/pages/documentation.html.erb
+++ b/app/views/pages/documentation.html.erb
@@ -78,7 +78,7 @@
       </ul>
       <li class="about_li">Finally, below the download options, you can see a frequency table of the top 10 domains found within the collection.</li>
     </ul>
-    <p class="about_p"><strong>Are you using Safari and having trouble with the network downloads?</strong> If so, note that Safari by default will add the ".xml" extension to your ".graphml" and ".gexf" downloads. To use the file, remove the .xml extension using Finder (rename the file to remove the trailing .xml).</p>
+    <p class="about_p"><strong>Are you using Safari and having trouble with the network downloads?</strong> If so, note that Safari by default will add the <code>.xml</code> extension to your <code>.graphml</code> and <code>.gexf</code> downloads. To use the file, remove the <code>.xml</code> extension using Finder (rename the file to remove the trailing <code>.xml</code>).</p>
     <%= image_tag("AUK_output.png", alt: "Output Files", class:"body_img")%>
 
     <h3 class="about_h3">Interactive Hyperlink Diagram</h3>

--- a/app/views/pages/documentation.html.erb
+++ b/app/views/pages/documentation.html.erb
@@ -78,6 +78,7 @@
       </ul>
       <li class="about_li">Finally, below the download options, you can see a frequency table of the top 10 domains found within the collection.</li>
     </ul>
+    <p class="about_p"><strong>Are you using Safari and having trouble with the network downloads?</strong> If so, note that Safari by default will add the ".xml" extension to your ".graphml" and ".gexf" downloads. To use the file, remove the .xml extension using Finder (rename the file to remove the trailing .xml).</p>
     <%= image_tag("AUK_output.png", alt: "Output Files", class:"body_img")%>
 
     <h3 class="about_h3">Interactive Hyperlink Diagram</h3>

--- a/app/views/pages/gephi.html.erb
+++ b/app/views/pages/gephi.html.erb
@@ -22,7 +22,7 @@
 
     <h3 class="about_h3">Loading Your Data into Gephi</h3>
     <p class="about_p">The downloaded .graphml file can be opened directly in Gephi by choosing "Open Graph File" from the Gephi startup screen and then selecting the file to be opened.</p>
-    <p class="about_p">Note that if you are using Safari, the file may come with an extra xml extension added to it (i.e. it will read <code>9745-gephi.gexf.xml</code>). You will need rename the file to remove <code>.xml</code>. The file should end with <code>.gexf</code>.</p>
+    <p class="about_p">Note that if you are using Safari, the file may come with an extra <code>.xml</code> extension added to it (i.e. it will read <code>9745-gephi.gexf.xml</code>). You will need rename the file to remove <code>.xml</code>. The file should end with <code>.gexf</code>.</p>
     <%= image_tag("Tutorial_OpenFile.png", alt: "The dialog box from Gephi showing how to open a graph file", class:"body_img")%>
     <p class="about_p">Once opened, we see from the statistics on the upper right hand corner that the collection has 4106 nodes, or individual websites, and 6817 connections between those websites, or edges.</p>
     <%= image_tag("Tutorial_Gexf.png", alt: "The Gephi interface, highlighting the context and data laboratory aspects", class:"body_img")%>

--- a/app/views/pages/gephi.html.erb
+++ b/app/views/pages/gephi.html.erb
@@ -22,6 +22,7 @@
 
     <h3 class="about_h3">Loading Your Data into Gephi</h3>
     <p class="about_p">The downloaded .graphml file can be opened directly in Gephi by choosing "Open Graph File" from the Gephi startup screen and then selecting the file to be opened.</p>
+    <p class="about_p">Note that if you are using Safari, the file may come with an extra xml extension added to it (i.e. it will read <code>9745-gephi.gexf.xml</code>). You will need rename the file to remove <code>.xml</code>. The file should end with <code>.gexf</code>.</p>
     <%= image_tag("Tutorial_OpenFile.png", alt: "The dialog box from Gephi showing how to open a graph file", class:"body_img")%>
     <p class="about_p">Once opened, we see from the statistics on the upper right hand corner that the collection has 4106 nodes, or individual websites, and 6817 connections between those websites, or edges.</p>
     <%= image_tag("Tutorial_Gexf.png", alt: "The Gephi interface, highlighting the context and data laboratory aspects", class:"body_img")%>


### PR DESCRIPTION
I've seen this issue now at both a workshop and our recent hackathon. As noted in #206, Safari adds `.xml` to the end of the `gexf` and `graphml` downloads. I've played around with various settings in the browser preferences, and I think the most straightforward instruction is for users to just remove the `.xml` extension.

If they don't, the file won't load in Gephi.