### PR TITLE
Updating/adding additional Slack links,closes #213

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -19,7 +19,7 @@
     <p class="about_p">The Archives Unleashed Project was born out of the need to create accessible and user-friendly tools in order to work with web archives. As a web-based interface, AUK allows researchers an opportunity to handle and analyze web archives without having to spend time delving into the technical world.</p>
 
   <h3 class=about_h3>How can I use AUK?</h3>
-    <p class="about_p">We are currently working to improve our documentation section, please check back shortly.</p>
+    <p class="about_p">Start by reading our <%=link_to('detailed documentation','/documentation') %>! If you have technical support questions, please join our <%= link_to('Slack channel', 'http://slack.archivesunleashed.org', target: '_blank') %> and add the #auk-support channel.</p>
 
   <h3 class=about_h3>Who can use AUK?</h3>
     <p class="about_p">Currently, those who maintain an <%= link_to('Archive-It', 'https://archive-it.org', target: '_blank') %> account will be able to ingest, download, and analyze their web archives collections in AUK. The AUT team is looking at ways to expand future functionality of AUK users.</p>
@@ -60,7 +60,7 @@
     <p class="about_p">Other financial and in-kind support comes from the <%= link_to('Social Sciences and Humanities Research Council', 'http://www.sshrc-crsh.gc.ca', target: '_blank') %>, <%= link_to('Compute Canada', 'https://www.computecanada.ca', target: '_blank') %>, the <%= link_to('Ontario Ministry of Research, Innovation, and Science', 'https://www.ontario.ca/page/ministry-research-innovation-and-science', target: '_blank') %>, and <%= link_to('Start Smart Labs', 'http://www.startsmartlabs.com', target: '_blank') %>
 
   <h3 class=about_h3>How can I contact the AUK team?</h3>
-    <p class="about_p">Join our <%= link_to('Slack team', 'https://docs.google.com/forms/d/e/1FAIpQLScXPIH0Ssw63yWqyMkUqHVYmz2-ItBMzHiJQ-sOlJwTA8u5AQ/viewform?usp=sf_link', target: '_blank') %> if you want to see how things are developing, to discuss suggestions or other parts of our project, or to just shoot the breeze about all things web archiving. You can also follow us on <%= link_to('Twitter', 'https://twitter.com/unleasharchives', target: '_blank') %>!</p>
-    <p class="about_p">Alternatively, please just drop us a line via e-mail at <%= link_to('archivesunleashed@gmail.com', 'mailto:archivesunleashed@gmail.com', target: '_blank') %>.</p>
+    <p class="about_p">Join our <%= link_to('Slack team', 'http://slack.archivesunleashed.org', target: '_blank') %> if you want to see how things are developing, to discuss suggestions or other parts of our project, or to just shoot the breeze about all things web archiving. You can also follow us on <%= link_to('Twitter', 'https://twitter.com/unleasharchives', target: '_blank') %>!</p>
+    <p class="about_p">Alternatively, please just drop us a line via e-mail at <%= link_to('sam.fritz@archivesunleashed.org', 'mailto:sam.fritz@archivesunleashed.org', target: '_blank') %>.</p>
 </div>
 <% end %>

--- a/app/views/pages/documentation.html.erb
+++ b/app/views/pages/documentation.html.erb
@@ -98,7 +98,7 @@
     <%= image_tag("AUK_hover.png", alt: "AUK Interactive Hyperlink Diagram hover feature", class:"body_img")%>
 
     <h3 class="about_h3">Need More Help?</h3>
-    <p class="about_p">Is your question or issue not discussed above? We'd love to hear more. Please join our <%= link_to('Slack channel', 'http://slack.archivesunleashed.org', target: '_blank') %> (the #auk-support channel is dedicated to these queries!) or check out the <%= link_to('"get involved"', 'https://archivesunleashed.org/get-involved/', target: '_blank') %> section of our website.</p>
+    <p class="about_p">Is your question or issue not discussed above? We'd love to hear more. Please join our <%= link_to('Slack channel', 'http://slack.archivesunleashed.org', target: '_blank') %> (the #auk-support channel is dedicated to these queries!) or check out the <%= link_to('get involved', 'https://archivesunleashed.org/get-involved/', target: '_blank') %> section of our website.</p>
 
 
   </div>

--- a/app/views/pages/documentation.html.erb
+++ b/app/views/pages/documentation.html.erb
@@ -7,7 +7,8 @@
     <h3 class=about_h3>Introduction</h3>
     <p class="about_p">The Archives Unleashed Cloud, referred to as AUK, is an open-source cloud-based analysis tool that helps researchers and scholars conduct web archive analysis.</p>
     <p class="about_p">AUK is a component of the <%= link_to('Archives Unleashed Project', 'https://archivesunleashed.org', target: '_blank') %>, which empowers researchers, scholars, librarians and archivists to access and explore their web archival collections. As accessibility is a main priority of the project, AUK supports this goal by providing a web-based front end for users to access the <%= link_to('Archives Unleashed Toolkit', 'https://archivesunleashed.org/aut/', target: '_blank') %>.</p>
-    <p class="about_p"> For more information on the AUK platform, as well as the basics of web archiving and the WARC file format, check out our <%=link_to("about", "/about/")%> page.</p>
+    <p class="about_p">For more information on the AUK platform, as well as the basics of web archiving and the WARC file format, check out our <%=link_to("about", "/about/")%> page.</p>
+    <p class="about_p">If you have questions about the documentation or are running into issues while using the tool, please join our <%= link_to('Slack channel', 'http://slack.archivesunleashed.org', target: '_blank') %> and join the #auk-support channel. We would love to connect with you there.</p> 
 
     <h3 class=about_h3>Audience and Application</h3>
     <p class="about_p">AUK is designed to provide a web-based user interface to help users access and analyze their web archive collections. This cloud-based option uses the <%= link_to('WASAPI Data Transfer API', 'https://github.com/WASAPI-Community/data-transfer-apis', target: '_blank') %>, which means that individuals already set up with an <%= link_to('Archive-It', 'https://archive-it.org/', target: '_blank') %> account will be able to ingest and explore WARC files. In the future, we are exploring interoperability with other web archiving platforms.</p>
@@ -95,5 +96,10 @@
     <p class="about_p">You can further interact with the hyperlink diagram by hovering over any node to highlight its immediate connections to other nodes. The arrow on each line indicates the direction of connection, for instance, in the image below, we see an arrow connecting two nodes and reveals the townyarmouth.ca has a link to the atlantic.ctvnews.ca domain. </p>
     <%= image_tag("AUK_neighbours.png", alt: "AUK Interactive Hyperlink Diagram Explained", class:"body_img")%>
     <%= image_tag("AUK_hover.png", alt: "AUK Interactive Hyperlink Diagram hover feature", class:"body_img")%>
+
+    <h3 class="about_h3">Need More Help?</h3>
+    <p class="about_p">Is your question or issue not discussed above? We'd love to hear more. Please join our <%= link_to('Slack channel', 'http://slack.archivesunleashed.org', target: '_blank') %> (the #auk-support channel is dedicated to these queries!) or check out the <%= link_to('"get involved"', 'https://archivesunleashed.org/get-involved/', target: '_blank') %> section of our website.</p>
+
+
   </div>
 <% end %>

--- a/app/views/pages/faq.html.erb
+++ b/app/views/pages/faq.html.erb
@@ -4,6 +4,7 @@
 <div class="container">
   <h1 class=about_h1>Frequently Asked Questions</h1>
   <p class="about_p">Have questions about the Archives Unleashed Cloud? Check out some of our most frequently asked questions.</p>
+  <p class="about_p">Is your question not listed here or would you prefer to talk to a human? Then join our <%= link_to('Slack channel', 'http://slack.archivesunleashed.org', target: '_blank') %> and add the #auk-support channel!</p>
   <div class="auk_faq_accordionContainer accordion">
     <div class="auk_deriv_accord card">
       <div class="auk_deriv_accord-header card-header" id="headingOne">


### PR DESCRIPTION
**GitHub issue(s)**:

#213

# What does this Pull Request do?

This is a relatively straightforward pull request. It changes any existing Slack signups links from the Google Doc to the new one at <http://slack.archivesunleashed.org>. It also adds a few more references to this, noting the #auk-support channel, so that people know that they can join our Slack group for any support queries.

It also updates the e-mail address from gmail to archivesunleashed. Given the general tenor of #213, I think this was in scope.

# How should this be tested?

Travis should turn Green.

@SamFritz and @ruebot should review text to make sure I haven't added any typos, that the prose and instructions make sense, and that I haven't broken any HTML.

# Interested parties

@SamFritz @ruebot 