### PR TITLE
Change AUK to Cloud throughout site, resolves #243

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -6,8 +6,8 @@
     <p class="about_p"><em>Helping researchers and scholars access and analyze petabytes of historical internet content.</em></p>
 
   <h3 class=about_h3>Project Overview</h3>
-    <p class="about_p">The Archives Unleashed Cloud, referred to as AUK, is an open source cloud-based analysis tool that helps researchers and scholars conduct web archive analysis.</p>
-    <p class="about_p">AUK is a component of the <%= link_to('Archives Unleashed Project', 'https://archivesunleashed.org', target: '_blank') %>, which aims to allow researchers, scholars, librarians and archivists the ability to access and investigate their web archival collections. As accessibility is a main priority of the project, AUK supports this goal by providing a web-based front end for users to access the <%= link_to('Archives Unleashed Toolkit', 'https://archivesunleashed.org/aut/', target: '_blank') %>.
+    <p class="about_p">The Archives Unleashed Cloud is an open source cloud-based analysis tool that helps researchers and scholars conduct web archive analysis.</p>
+    <p class="about_p">The Cloud is a component of the <%= link_to('Archives Unleashed Project', 'https://archivesunleashed.org', target: '_blank') %>, which aims to allow researchers, scholars, librarians and archivists the ability to access and investigate their web archival collections. As accessibility is a main priority of the project, the Cloud supports this goal by providing a web-based front end for users to access the <%= link_to('Archives Unleashed Toolkit', 'https://archivesunleashed.org/aut/', target: '_blank') %>.
 
   <h3 class=about_h3>What is Web Archiving, what are WARCS, and why should I care?</h3>
     <p class="about_p"><strong>Web archiving</strong> is the process of preserving born-digital content on the World Wide Web. Thinking about how curated content is organized, there are two main components:</p>
@@ -16,33 +16,33 @@
       <li class="about_li"><strong>WARC record</strong>: contains all of the data of a webpage and contains a record header and the record content block.</li>
     </ul>
     <p class="about_p">The exponential rise of digitally-born data offers a unique opportunity for scholarly inquiry. However the sheer scale of web archives can be an overwhelming process for librarians, archivists, and other curators who face several challenges when working with this material. One of the largest challenges relates to accessibility. This includes a shortage of tools or tools that are largely beyond the skill base of researchers.</p>
-    <p class="about_p">The Archives Unleashed Project was born out of the need to create accessible and user-friendly tools in order to work with web archives. As a web-based interface, AUK allows researchers an opportunity to handle and analyze web archives without having to spend time delving into the technical world.</p>
+    <p class="about_p">The Archives Unleashed Project was born out of the need to create accessible and user-friendly tools in order to work with web archives. As a web-based interface, the Archives Unleashed Cloud allows researchers an opportunity to handle and analyze web archives without having to spend time delving into the technical world.</p>
 
-  <h3 class=about_h3>How can I use AUK?</h3>
+  <h3 class=about_h3>How can I use the Cloud?</h3>
     <p class="about_p">We are currently working to improve our documentation section, please check back shortly.</p>
 
-  <h3 class=about_h3>Who can use AUK?</h3>
-    <p class="about_p">Currently, those who maintain an <%= link_to('Archive-It', 'https://archive-it.org', target: '_blank') %> account will be able to ingest, download, and analyze their web archives collections in AUK. The AUT team is looking at ways to expand future functionality of AUK users.</p>
+  <h3 class=about_h3>Who can use the Cloud?</h3>
+    <p class="about_p">Currently, those who maintain an <%= link_to('Archive-It', 'https://archive-it.org', target: '_blank') %> account will be able to ingest, download, and analyze their web archives collections in the Cloud. The Archives Unleashed team is looking at ways to expand future functionality of Cloud users.</p>
 
-  <h3 class=about_h3>What can I do in AUK?</h3>
-    <p class="about_p">Our goal is to get users to a point where they can really dig down into WARC files to explore their research questions. The core features of AUK include:</p>
+  <h3 class=about_h3>What can I do in the Cloud?</h3>
+    <p class="about_p">Our goal is to get users to a point where they can really dig down into WARC files to explore their research questions. The core features of the Cloud include:</p>
     <ul class="about_ul">
       <li class="about_li"><strong>Ingesting Archive-It collections</strong> via <%= link_to('WASAPI', 'https://github.com/WASAPI-Community/data-transfer-apis', target: '_blank') %>.</li>
       <li class="about_li"><strong>Download collection derivatives</strong>: network files, domain lists, full text, and full text by domain.</li>
       <li class="about_li"><strong>In-browser network diagram</strong> to see major nodes and connections within your collection.</li>
     </ul>
 
-  <h3 class=about_h3>Who Created AUK?</h3>
+  <h3 class=about_h3>Who Created the Archives Unleashed Cloud?</h3>
     <p class="about_p">A digital librarian, historian, and computer science professor met for coffee....well there is a little more to that.</p>
-    <p class="about_p">We are very lucky to have some very talented and passionate individuals usher the Archives Unleashed Project and AUK into existence.</p>
+    <p class="about_p">We are very lucky to have some very talented and passionate individuals to usher the Archives Unleashed Project and Cloud into existence.</p>
     <ul class="about_ul">
-      <li class="about_li"><strong><%= link_to('Nick Ruest', 'https://ruebot.net/', target: '_blank') %></strong>, Co-Investigator and <%= link_to('AUK', 'https://github.com/archivesunleashed/auk', target: '_blank') %> Lead</li>
-      <li class="about_li"><strong><%= link_to('Ian Milligan', 'http://ianmilligan.ca', target: '_blank') %></strong>, Primary Investigator and AUK Developer</li>
-      <li class="about_li"><strong><%= link_to('Jimmy Lin', 'https://cs.uwaterloo.ca/~jimmylin/', target: '_blank') %></strong>, Co-Investigator and <%= link_to('AUT', 'https://github.com/archivesunleashed/aut', target: '_blank') %> Lead</li>
+      <li class="about_li"><strong><%= link_to('Nick Ruest', 'https://ruebot.net/', target: '_blank') %></strong>, Co-Investigator and <%= link_to('Cloud', 'https://github.com/archivesunleashed/auk', target: '_blank') %> Lead</li>
+      <li class="about_li"><strong><%= link_to('Ian Milligan', 'http://ianmilligan.ca', target: '_blank') %></strong>, Primary Investigator and Cloud Developer</li>
+      <li class="about_li"><strong><%= link_to('Jimmy Lin', 'https://cs.uwaterloo.ca/~jimmylin/', target: '_blank') %></strong>, Co-Investigator and <%= link_to('Toolkit', 'https://github.com/archivesunleashed/aut', target: '_blank') %> Lead</li>
       <li class="about_li"><strong><%= link_to('Samantha Fritz', 'https://uwaterloo.ca/web-archive-group/people-profiles/samantha-fritz', target: '_blank') %></strong>, Project Manager</li>
-      <li class="about_li"><strong><%= link_to('Ryan Deschamps', 'https://uwaterloo.ca/web-archive-group/people-profiles/ryan-deschamps', target: '_blank') %></strong> AUK Tester and <%= link_to('GraphPass Developer', 'https://github.com/archivesunleashed/graphpass', target: '_blank') %></li>
+      <li class="about_li"><strong><%= link_to('Ryan Deschamps', 'https://uwaterloo.ca/web-archive-group/people-profiles/ryan-deschamps', target: '_blank') %></strong> Cloud Tester and <%= link_to('GraphPass Developer', 'https://github.com/archivesunleashed/graphpass', target: '_blank') %></li>
     </ul>
-    <p class="about_p">A special thank you to Sarah McTavish, a PhD Candidate at the University of Waterloo, who  developed the <%=link_to("AUK Learning Guides", "/derivatives/")%>.</p>
+    <p class="about_p">A special thank you to Sarah McTavish, a PhD Candidate at the University of Waterloo, who  developed the <%=link_to("Archives Unleashed Cloud Learning Guides", "/derivatives/")%>.</p>
     <p class="about_p">We would also like to acknowledge the groups and individuals who have inspired and informed our work:</p>
     <ul class="about_ul">
       <li class="about_li"><%= link_to('Web Archives for Longitudinal Knowledge (WALK) Portal', 'http://webarchives.ca', target: '_blank') %></li>
@@ -52,14 +52,14 @@
       <li class="about_li"><%= link_to('Internet Archive', 'https://archive.org', target: '_blank') %></li>
     </ul>
 
-  <h3 class=about_h3>How much does AUK cost to use?</h3>
+  <h3 class=about_h3>How much does the Cloud cost to use?</h3>
     <p class="about_p">The Archives Unleashed Cloud is currently <strong>free</strong>. Yep, you heard right! The generous support from the <%= link_to('Andrew W. Mellon Foundation', 'https://mellon.org', target: '_blank') %> and contributions from our team, developers, and community have made this possible. We will keep our users and community updated as we move towards a sustainable future.</p>
 
   <h3 class=about_h3>Who funds the Archives Unleashed Cloud?</h3>
     <p class="about_p">This work is primarily supported by the <%= link_to('Andrew W. Mellon Foundation', 'https://mellon.org/', target: '_blank') %>, the <%= link_to('University of Waterloo', 'http://uwaterloo.ca', target: '_blank') %>, and  <%= link_to('York University Libraries', 'https://www.library.yorku.ca/web/', target: '_blank') %>.</p>
     <p class="about_p">Other financial and in-kind support comes from the <%= link_to('Social Sciences and Humanities Research Council', 'http://www.sshrc-crsh.gc.ca', target: '_blank') %>, <%= link_to('Compute Canada', 'https://www.computecanada.ca', target: '_blank') %>, the <%= link_to('Ontario Ministry of Research, Innovation, and Science', 'https://www.ontario.ca/page/ministry-research-innovation-and-science', target: '_blank') %>, and <%= link_to('Start Smart Labs', 'http://www.startsmartlabs.com', target: '_blank') %>
 
-  <h3 class=about_h3>How can I contact the AUK team?</h3>
+  <h3 class=about_h3>How can I contact the Archives Unleashed team?</h3>
     <p class="about_p">Join our <%= link_to('Slack team', 'https://docs.google.com/forms/d/e/1FAIpQLScXPIH0Ssw63yWqyMkUqHVYmz2-ItBMzHiJQ-sOlJwTA8u5AQ/viewform?usp=sf_link', target: '_blank') %> if you want to see how things are developing, to discuss suggestions or other parts of our project, or to just shoot the breeze about all things web archiving. You can also follow us on <%= link_to('Twitter', 'https://twitter.com/unleasharchives', target: '_blank') %>!</p>
     <p class="about_p">Alternatively, please just drop us a line via e-mail at <%= link_to('archivesunleashed@gmail.com', 'mailto:archivesunleashed@gmail.com', target: '_blank') %>.</p>
 </div>

--- a/app/views/pages/derivatives.html.erb
+++ b/app/views/pages/derivatives.html.erb
@@ -4,7 +4,7 @@
   <div class="container">
     <h1 class="about_h1">Using the Archives Unleashed Cloud Derivative Files</h1>
     <p class="about_p">One of the main features of the Archives Unleashed Cloud is the creation of <strong>derivative files</strong>. These are datasets that provide information about your web archives and can be used by researchers in place of the original WARC files.</p>
-    <p class="about_p">Once analytics have been run on a collection, as discussed in the <%=link_to('AUK documentation','/documentation') %>, you will be able to view and access a series of four derivative files.</p>
+    <p class="about_p">Once analytics have been run on a collection, as discussed in the <%=link_to('documentation','/documentation') %>, you will be able to view and access a series of four derivative files.</p>
     <div class="auk_deriv_card-deck card-deck">
       <div class="auk_deriv_card card">
         <%= image_tag("DER-gexf-197x330.png", alt: "Gephi File Output", class:"auk_card-img-top")%>
@@ -33,7 +33,7 @@
     </div>
     <br />
     <h3 class="about_h3">Learning Guides</h3>
-      <p class="about_p">The following guides walk through how to use AUK derivative files for further analysis.</p>
+      <p class="about_p">The following guides walk through how to use Cloud derivative files for further analysis.</p>
     <div id="auk_deriv_accordionContainer accordion">
       <div class="auk_deriv_accord card">
         <div class="auk_deriv_accord-header card-header" id="headingOne">
@@ -80,7 +80,7 @@
         </div>
         <div id="collapseTwo" class="collapse" aria-labelledby="headingTwo" data-parent="#accordion">
           <div class="auk_deriv_accord_body card-body">
-            <p class="about_p">The full text of a web collection can be invaluable for a researcher! AUK users will have access to the full text file. In it, each website within the web archive collection will have its full text presented on one line, along with information around when it was crawled, the name of the domain, and the full URL of the content.</p>
+            <p class="about_p">The full text of a web collection can be invaluable for a researcher! Archives Unleashed Cloud users will have access to the full text file. In it, each website within the web archive collection will have its full text presented on one line, along with information around when it was crawled, the name of the domain, and the full URL of the content.</p>
             <table id="auk_deriv_accord_table">
               <tbody class="auk_deriv_tbody_table">
                 <tr class="auk_deriv_tr_table">

--- a/app/views/pages/documentation.html.erb
+++ b/app/views/pages/documentation.html.erb
@@ -5,13 +5,13 @@
     <h1 class=about_h1>Documentation</h1>
 
     <h3 class=about_h3>Introduction</h3>
-    <p class="about_p">The Archives Unleashed Cloud, referred to as AUK, is an open-source cloud-based analysis tool that helps researchers and scholars conduct web archive analysis.</p>
-    <p class="about_p">AUK is a component of the <%= link_to('Archives Unleashed Project', 'https://archivesunleashed.org', target: '_blank') %>, which empowers researchers, scholars, librarians and archivists to access and explore their web archival collections. As accessibility is a main priority of the project, AUK supports this goal by providing a web-based front end for users to access the <%= link_to('Archives Unleashed Toolkit', 'https://archivesunleashed.org/aut/', target: '_blank') %>.</p>
-    <p class="about_p"> For more information on the AUK platform, as well as the basics of web archiving and the WARC file format, check out our <%=link_to("about", "/about/")%> page.</p>
+    <p class="about_p">The Archives Unleashed Cloud is an open-source cloud-based analysis tool that helps researchers and scholars conduct web archive analysis.</p>
+    <p class="about_p">The Cloud is a component of the <%= link_to('Archives Unleashed Project', 'https://archivesunleashed.org', target: '_blank') %>, which empowers researchers, scholars, librarians and archivists to access and explore their web archival collections. As accessibility is a main priority of the project, the Archives Unleashed Cloud supports this goal by providing a web-based front end for users to access the <%= link_to('Archives Unleashed Toolkit', 'https://archivesunleashed.org/aut/', target: '_blank') %>.</p>
+    <p class="about_p"> For more information on the Cloud platform, as well as the basics of web archiving and the WARC file format, check out our <%=link_to("about", "/about/")%> page.</p>
 
     <h3 class=about_h3>Audience and Application</h3>
-    <p class="about_p">AUK is designed to provide a web-based user interface to help users access and analyze their web archive collections. This cloud-based option uses the <%= link_to('WASAPI Data Transfer API', 'https://github.com/WASAPI-Community/data-transfer-apis', target: '_blank') %>, which means that individuals already set up with an <%= link_to('Archive-It', 'https://archive-it.org/', target: '_blank') %> account will be able to ingest and explore WARC files. In the future, we are exploring interoperability with other web archiving platforms.</p>
-    <p class="about_p">With AUK you can:</p>
+    <p class="about_p">The Archives Unleashed Cloud is designed to provide a web-based user interface to help users access and analyze their web archive collections. This cloud-based option uses the <%= link_to('WASAPI Data Transfer API', 'https://github.com/WASAPI-Community/data-transfer-apis', target: '_blank') %>, which means that individuals already set up with an <%= link_to('Archive-It', 'https://archive-it.org/', target: '_blank') %> account will be able to ingest and explore WARC files. In the future, we are exploring interoperability with other web archiving platforms.</p>
+    <p class="about_p">With the Cloud you can:</p>
     <ul class="about_ul">
       <li class="about_li">Ingest Archive-It collections via WASAPI;</li>
       <li class="about_li">Download collection derivatives: network files, domain lists, and full text (all and by domain); and</li>
@@ -20,30 +20,30 @@
     <p class="about_note"><strong>Note</strong>: You can use our canonical version at <%= link_to('https://cloud.archivesunleashed.org', 'https://cloud.archivesunleashed.org', target: '_blank') %>, or you are welcome to run your own local version by visiting our <%= link_to('GitHub repository', 'https://github.com/archivesunleashed/auk', target: '_blank') %>.</p>
 
     <h3 class=about_h3>Getting Started</h3>
-    <p class="about_p"> This guide will walk through how to set up an AUK account and sync your Archive-It collections, and the types of analysis outputs you can curate.</p>
+    <p class="about_p"> This guide will walk through how to set up a Cloud account and sync your Archive-It collections, and the types of analysis outputs you can curate.</p>
 
     <h3 class="about_h3">Login</h3>
     <p class="about_p">Begin at <%=link_to("https://cloud.archivesunleashed.org", "https://cloud.archivesunleashed.org")%>.</p>
-    <p class="about_p">You will not need to sign up for an AUK account. Instead, AUK will use either a <%=link_to("Twitter", "https://twitter.com/")%> or <%=link_to("GitHub", "https://github.com/")%> account to authenticate your login. For those who have multiple Twitter or GitHub accounts, feel free to use whichever suits your research purposes best. AUK only uses these accounts to authenticate who you are, we do not have any additional access to your Twitter or GitHub account!</p>
+    <p class="about_p">You will not need to sign up for a Cloud account. Instead, the Cloud will use either a <%=link_to("Twitter", "https://twitter.com/")%> or <%=link_to("GitHub", "https://github.com/")%> account to authenticate your login. For those who have multiple Twitter or GitHub accounts, feel free to use whichever suits your research purposes best. The Cloud only uses these accounts to authenticate who you are, we do not have any additional access to your Twitter or GitHub account!</p>
     <p class="about_p">The following two screenshots show you how to log in. Click on the logo of the service you want to use to authenticate (the bird for Twitter or the Octocat for GitHub). After you authenticate, you should be brought to the main page.</p>
     <%= image_tag("AUK_signin.png", alt: "AUK Sign In Screenshot", class:"body_img")%>
     <%= image_tag("AUK_login.png", alt: "AUK Log In Screenshot", class:"body_img")%>
-    <p class="about_p">You are now logged into AUK. Welcome!</p>
+    <p class="about_p">You are now logged into the Cloud. Welcome!</p>
 
     <h3 class="about_h3">Account Set Up</h3>
-    <p class="about_p">The left hand panel displays two sets of credentials: 1) AU Cloud account and 2) Archive-It account. You will also notice that the main collections space at right is empty. That's because before you have connected AUK to your Archive-It account, there are no collections to show. Let's walk through setting up your account.</p>
+    <p class="about_p">The left hand panel displays two sets of credentials: 1) AU Cloud account and 2) Archive-It account. You will also notice that the main collections space at right is empty. That's because before you have connected the Cloud to your Archive-It account, there are no collections to show. Let's walk through setting up your account.</p>
     <p class="about_p">Click <strong>Enter Credentials</strong> in the left hand panel (highlighted in the screenshot below).</p>
     <%= image_tag("AUK_creds.png", alt: "AUK Account Credentials", class:"body_img")%>
     <p class="about_p">On the next screen, fill out the form to update both sets of credentials.</p>
     <ul class="about_ul">
-      <li class="about_li"><strong>AU Account Information</strong>: AUK requires an email so we can let you know what stage of analysis your collection is in. You can use the email address of your choice, and have the ability to modify this at any time. If you have a <%= link_to('Gravatar', 'https://gravatar.com', target: '_blank') %> account, it will also use this email address to populate your user avatar.</li>
+      <li class="about_li"><strong>AU Account Information</strong>: The Cloud requires an email so we can let you know what stage of analysis your collection is in. You can use the email address of your choice, and have the ability to modify this at any time. If you have a <%= link_to('Gravatar', 'https://gravatar.com', target: '_blank') %> account, it will also use this email address to populate your user avatar.</li>
       <li class="about_li"><strong>Consent Checkbox</strong>: to comply with Canadian Anti-Spam legislation, we've included this checkbox to make sure you understand that the Archives Unleashed team will connect with you in regards to your collections and feedback.</li>
       <li class="about_li"><strong>Archive-It Information</strong>: In order to work with web archive collections, you must enter your Archive-It account username and password. Your Archive-It credentials are encrypted and salted.</li>
     </ul>
     <%= image_tag("AUK_account_info.png", alt: "AUK Account Credentials Log In Screenshot", class:"body_img")%>
     <%= image_tag("AUK_account_info2.png", alt: "AUK Account Credentials Log In Screenshot", class:"body_img")%>
     <p class="about_p">Click <strong>Update</strong></p>
-    <p class="about_p">You will be redirected back into the main space. A note at the top of the page will indicate that AUK is syncing with your Archive-It account. The length of time to ingest your collections will depend on the size of your collections and the number of other users syncing their collections. This process could take a few minutes to a few hours. You will receive an email, to the address you provided for your AU Cloud account, when the collections are synced.</p>
+    <p class="about_p">You will be redirected back into the main space. A note at the top of the page will indicate that the Cloud is syncing with your Archive-It account. The length of time to ingest your collections will depend on the size of your collections and the number of other users syncing their collections. This process could take a few minutes to a few hours. You will receive an email, to the address you provided for your AU Cloud account, when the collections are synced.</p>
     <%= image_tag("AUK_user.png", alt: "AUK Account Credentials Log In Screenshot", class:"body_img")%>
     <p class="about_note"><strong>Note</strong>: You may update/change your AU Cloud or Archive-It credentials at any time by clicking <strong>Update</strong>. If you add a new collection in Archive-It or change your Archive-It credentials, you can click <strong>Update</strong> and redo the above steps to re-sync.</p>
 
@@ -51,7 +51,7 @@
     <p class="about_p">Once your collections have been synced, you can return to the main collections screen and start analysis. You can sort collections by clicking on the arrows beside each header. Let's take a look at the collection information available to us in the main space:</p>
     <ul class="about_ul">
       <li class="about_li"><strong>Title</strong> - The name of each collection is pulled directly from your Archive-It account; each title provides the access point for analysis.</li>
-      <li class="about_li"><strong>Analyzed</strong> - This header identifies whether a collection has been analyzed in AUK. If yes, you will see at least one of the following; a network diagram, downloadable derivative files, and/or a domains frequency table once you enter the collection's page.</li>
+      <li class="about_li"><strong>Analyzed</strong> - This header identifies whether a collection has been analyzed in the Cloud. If yes, you will see at least one of the following; a network diagram, downloadable derivative files, and/or a domains frequency table once you enter the collection's page.</li>
       <li class="about_li"><strong>Public</strong> - This field notes whether or not the collection is public, and if so, will be listed on an institution's Archive-It page.</li>
       <li class="about_li"><strong>Files</strong> - Indicates the number of ARC or WARC files in each collection. Note, this size will differ from the collection size in your Archive-It dashboard. The Archive-It WASAPI endpoint provides the size of each compressed WARC. Whereas the Archive-It dashboard will provide the size of a collection uncompressed.</li>
       <li class="about_li"><strong>Size</strong> - Indicates the collection's total file size.</li>
@@ -60,7 +60,7 @@
 
     <h3 class="about_h3">Analysis</h3>
     <p class="about_p">Click on the name of the collection you would like to analyze. This will bring you into the collection page.</p>
-    <p class="about_p">At the top of the screen, click <strong>Analyze Collection</strong>. You do not need to keep AUK or your browser open for it to analyze the collection. AUK will notify you when the process is complete and ready for you to start using the output files.</p>
+    <p class="about_p">At the top of the screen, click <strong>Analyze Collection</strong>. You do not need to keep the Cloud or your browser open for it to analyze the collection. We will notify you when the process is complete and ready for you to start using the output files.</p>
     <p class="about_note"><strong>Note</strong>: We operate on a queuing system so the time it takes to analyze the collection will depend on how large the collection is and how many other users are processing collections. This could take anywhere between half an hour to a few weeks. You need only click the button a single time.</p>
     <%= image_tag("AUK_analyze.png", alt: "Analyze the Collection", class:"body_img")%>
 
@@ -91,7 +91,7 @@
         <li class="about_li"><strong>Scale up/down</strong> - allows users to see more or less node labels in the network</li>
       </ul>
     <%= image_tag("AUK_hyperlink.png", alt: "AUK Interactive Hyperlink Diagram", class:"body_img")%>
-    <p class="about_p">A few cautionary notes on <strong>"scale up"</strong> and <strong>"scale down"</strong> are in order. With website networks, some sites have so many links compared to the others, that they obscure everything else. AUK's scale-up feature uses <%= link_to('logarithmic transformation', '#', data: { toggle: 'tooltip', title: 'A logarithm is a mathematical expression used to deal with non-normal distributed data (like networks). It is created by giving a base number an exponent, which is then multiplied by itself, to create factor increments, rather than equal amount increments, between data points. This is important as it will allow for data points to be more evenly distributed with minimal influence on data accuracy and integrity.'}) %> to make the graph a bit easier to read. For example, six nodes with size values 1, 10, 100, 1000, 10000 and 1,000,000,000 can be transformed using a base 10 logarithm to produce new sizes 0, 1, 2, 3, 4, & 9, making the node sizes much closer together in size.</p>
+    <p class="about_p">A few cautionary notes on <strong>"scale up"</strong> and <strong>"scale down"</strong> are in order. With website networks, some sites have so many links compared to the others, that they obscure everything else. The Cloud's scale-up feature uses <%= link_to('logarithmic transformation', '#', data: { toggle: 'tooltip', title: 'A logarithm is a mathematical expression used to deal with non-normal distributed data (like networks). It is created by giving a base number an exponent, which is then multiplied by itself, to create factor increments, rather than equal amount increments, between data points. This is important as it will allow for data points to be more evenly distributed with minimal influence on data accuracy and integrity.'}) %> to make the graph a bit easier to read. For example, six nodes with size values 1, 10, 100, 1000, 10000 and 1,000,000,000 can be transformed using a base 10 logarithm to produce new sizes 0, 1, 2, 3, 4, & 9, making the node sizes much closer together in size.</p>
     <p class="about_p">You can further interact with the hyperlink diagram by hovering over any node to highlight its immediate connections to other nodes. The arrow on each line indicates the direction of connection, for instance, in the image below, we see an arrow connecting two nodes and reveals the townyarmouth.ca has a link to the atlantic.ctvnews.ca domain. </p>
     <%= image_tag("AUK_neighbours.png", alt: "AUK Interactive Hyperlink Diagram Explained", class:"body_img")%>
     <%= image_tag("AUK_hover.png", alt: "AUK Interactive Hyperlink Diagram hover feature", class:"body_img")%>

--- a/app/views/pages/privacypolicy.html.erb
+++ b/app/views/pages/privacypolicy.html.erb
@@ -4,7 +4,7 @@
 <div class="container">
   <h1 class=about_h1>The Archives Unleashed Privacy Policy </h1>
     <p class="about_p">We recognize the importance of and are committed to protecting the privacy of all users. The following privacy policy guides and outlines the Archives Unleashed Project’s (AU) online information practices.</p>
-    <p class="about_p">The Archives Unleashed Privacy Policy describes what users can expect from Archives Unleashed as to how information is collected, used and shared. This policy applies to all information collected from or submitted to the Archives Unleashed Project, including the Archives Unleashed Cloud (AUK) portal located at <%= link_to('cloud.archivesunleashed.org','https://cloud.archivesunleashed.org/', target: '_blank') %> and all related sub-domains.</p>
+    <p class="about_p">The Archives Unleashed Privacy Policy describes what users can expect from Archives Unleashed as to how information is collected, used and shared. This policy applies to all information collected from or submitted to the Archives Unleashed Project, including the Archives Unleashed Cloud (the Cloud) portal located at <%= link_to('cloud.archivesunleashed.org','https://cloud.archivesunleashed.org/', target: '_blank') %> and all related sub-domains.</p>
     <p class="about_p">By accessing and using the services and products of the Archives Unleashed Project, users accept the practices outlined in the policy below.</p>
     <p class="about_p"><strong>Information Collection and Use</strong></p>
     <p class="about_p">We request the minimum amount of personal information necessary for the operation of Archives Unleashed software. We collect several types of information for various purposes to provide and improve our service to you.</p>

--- a/app/views/pages/text-filtering.html.erb
+++ b/app/views/pages/text-filtering.html.erb
@@ -15,19 +15,19 @@
     <p class="about_p">Fortunately, you can easily do this with some simple tools.</p>
 
     <h3 class="about_h3">Using Grep</h3>
-    <p class="about_p"><%= link_to('Grep','https://www.gnu.org/software/grep/manual/grep.html', target: '_blank') %> is a Unix utility that stands for "globally search a regular expression and print." In short, it lets you take a text file and find lines that match criteria that you specify. Grep is especially useful for working with the files that AUK generates because each line in the full-text file corresponds to one website in the collection.</p>
+    <p class="about_p"><%= link_to('Grep','https://www.gnu.org/software/grep/manual/grep.html', target: '_blank') %> is a Unix utility that stands for "globally search a regular expression and print." In short, it lets you take a text file and find lines that match criteria that you specify. Grep is especially useful for working with the files that the Cloud generates because each line in the full-text file corresponds to one website in the collection.</p>
     <p class="about_p">If you are on Linux or MacOS, you have Grep already installed. If you're on Windows, you will need to install a program called "Git Bash." You will want to find the "full installer" <%= link_to('here','https://git-for-windows.github.io/', target: '_blank') %>, and follow <%= link_to('these instructions to install','https://openhatch.org/missions/windows-setup/install-git-bash', target: '_blank') %>.</p>
     <p class="about_p">The command line is powerful, but not always straightforward. Fortunately, there is a good walkthrough at the Programming Historian: <%= link_to('Introduction to Bash','https://programminghistorian.org/en/lessons/intro-to-bash', target: '_blank') %>. For the purposes of this tutorial, you will want to be able to "find" files in the command line.</p>
 
     <h3 class="about_h3">A Command Line Example: Finding the Derivatives</h3>
-    <p class="about_p">In addition to the resources above, an example might give you a sense of how relatively straightforward it can be to locate files. Imagine that in the AUK interface, you download the "full text" file. On MacOS, this defaults to your "downloads" directory.</p>
+    <p class="about_p">In addition to the resources above, an example might give you a sense of how relatively straightforward it can be to locate files. Imagine that in the Cloud interface, you download the "full text" file. On MacOS, this defaults to your "downloads" directory.</p>
     <p class="about_p">To open the command line on MacOS, we go to our "Applications" folder, "Utilities," and then select "Terminal." You will see this window (your colours might be different):</p>
     <%= image_tag("tutorial_terminal.png", alt: "Screenshot of a terminal window", class:"body_img")%>
     <p class="about_p">By default, you start in your home user directory. You can now change the directory to downloads by typing:</p>
     <p class="about_p"><code>cd downloads</code></p>
     <p class="about_p">If you type:</p>
     <p class="about_p"><code>ls</code></p>
-    <p class="about_p">You will then see a long list of all of the files in this directory. Amongst them should be the file you downloaded from AUK! You could begin working on it here, or you could move it somewhere else on your file system. For more information on this, see the Bash tutorial above.</p>
+    <p class="about_p">You will then see a long list of all of the files in this directory. Amongst them should be the file you downloaded from the Cloud! You could begin working on it here, or you could move it somewhere else on your file system. For more information on this, see the Bash tutorial above.</p>
 
     <h3 class="about_h3">Finding Dates</h3>
     <p class="about_p">In the following example, I will use the files from the "Fort McMurray" collection. You can follow along with your own files, simply changing the collection number to your own (i.e. instead of 7368-fulltext.txt it might be 1234-fulltext.txt).</p>


### PR DESCRIPTION
**GitHub issue(s)**:

#243

# What does this Pull Request do?

As noted in #243, we use a lot of acronyms. This goes through the site and changes mention of AUK to either "Archives Unleashed Cloud" or just "the Cloud" where context is appropriate and clear. 

# How should this be tested?

TravisCI should turn green. Should also receive editorial review from @SamFritz and @ruebot.

# Interested parties

@SamFritz @ruebot 