### PR TITLE
Issue 259: Impliment Table of Contents

### DIFF
--- a/app/assets/stylesheets/auk/override_bootstrap.scss
+++ b/app/assets/stylesheets/auk/override_bootstrap.scss
@@ -274,6 +274,7 @@ body {
 
 .toc{
   border-style: dotted;
+  border-radius: 5px;
   background-color:#cce6ff;
   border-collapse: collapse;
   text-align: left;

--- a/app/assets/stylesheets/auk/override_bootstrap.scss
+++ b/app/assets/stylesheets/auk/override_bootstrap.scss
@@ -293,11 +293,17 @@ body {
 }
 .toc_list{
   padding-left: auto;
-  padding-top: 5px;
-  padding-bottom: 10px;
+  padding-top: 10px;
   line-height: 1.4;
   font-family: helvetica;
   font-size: 18px;
+}
+
+.toc-li{
+  padding-top: 5px;
+  padding-bottom: 5px;
+  line-height: 1.4;
+
 }
 
 .top_toc{

--- a/app/assets/stylesheets/auk/override_bootstrap.scss
+++ b/app/assets/stylesheets/auk/override_bootstrap.scss
@@ -268,6 +268,43 @@ body {
   padding: 15px;
   text-align:left;
   }
+/*
+ * AUK Derivative Pages - table of contents customization
+ */
+
+.toc{
+  border-style: dotted;
+  background-color:#cce6ff;
+  border-collapse: collapse;
+  text-align: left;
+  margin-left: 20px;
+  margin-top: 5px;
+  margin-bottom: 5px;
+}
+.toc_title{
+  font-family: helvetica;
+  font-size: 18px;
+  padding-left: 5px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  line-height: 1.4;
+  margin-left: 20px;
+  margin-right: 25px;
+}
+.toc_list{
+  padding-left: auto;
+  padding-top: 5px;
+  padding-bottom: 10px;
+  line-height: 1.4;
+  font-family: helvetica;
+  font-size: 18px;
+}
+
+.top_toc{
+  font-family: helvetica;
+  font-size: 12px;
+  text-align: right;
+}
 
 /*
  * Footer

--- a/app/assets/stylesheets/auk/override_bootstrap.scss
+++ b/app/assets/stylesheets/auk/override_bootstrap.scss
@@ -269,7 +269,7 @@ body {
   text-align:left;
   }
 /*
- * AUK Derivative Pages - table of contents customization
+ * AUK Derivative Pages - table of contents customization.
  */
 
 .toc{
@@ -282,6 +282,7 @@ body {
   margin-top: 5px;
   margin-bottom: 5px;
 }
+
 .toc_title{
   font-family: helvetica;
   font-size: 18px;
@@ -292,6 +293,7 @@ body {
   margin-left: 20px;
   margin-right: 25px;
 }
+
 .toc_list{
   padding-left: auto;
   padding-top: 10px;

--- a/app/views/pages/basic-gephi.html.erb
+++ b/app/views/pages/basic-gephi.html.erb
@@ -4,20 +4,30 @@
   <div class="container">
     <h1 class="about_h1">An Introduction to Gephi</h1>
     <p class="about_p_italic">Tutorial by Ian Milligan (University of Waterloo)</p>
-
-    <h3 class="about_h3">Introduction</h3>
+    <div class="toc">
+        <ul class="toc_list">
+          <li class="toc-li"><%=link_to('Introduction', anchor: '1toc') %></li>
+          <li class="toc-li"><%=link_to('Getting Started: Importing Data', anchor: '2toc') %></li>
+          <li class="toc-li"><%=link_to('Basic Graph Layouts', anchor: '3toc') %></li>
+          <li class="toc-li"><%=link_to('Applying a Statistical Analysis', anchor: '4toc') %></li>
+        </ul>
+    </div>
+    <br>
+    <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">This is a very basic introduction to Gephi. It begins with the assumption of no knowledge around Gephi, and explains how you can import the file you receive from AUK and do some basic transformations on it yourself.</p>
     <p class="about_p">While your graphs have some basic characteristics computed for them, you may want to start from fresh and learn some of the basics.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Getting Started: Importing Data</h3>
+    <h3 class="about_h3" id="2toc">Getting Started: Importing Data</h3>
     <p class="about_p">This tutorial explores what you can learn from the derivative file marked as "Gephi" or "Raw Network" in your collections page. You can find this by selecting the Gephi or Raw Network derivative. See the screenshot below:</p>
     <%= image_tag("download-gexf.png", alt: "The derivative download buttons with the Gephi one highlighted", class:"body_img")%>
     <p class="about_p">The first step is to download and install Gephi, which you can find <%= link_to('here', 'http://gephi.github.io/', target: '_blank') %>.</p>
     <p class="about_p">Upon opening the Gephi application, you want to select “Open a Graph File...” and select the GEXF file that you have downloaded from AUK.</p>
     <%= image_tag("gephi-1.png", alt: "The opening page for the Gephi application", class:"body_img")%>
     <p class="about_p">You then want to click 'ok' on the next page. You can see in the sample data that you have a network with 125 nodes (or domains) with 200 edges (or links between those domains).</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Basic Graph Layouts</h3>
+    <h3 class="about_h3" id="3toc">Basic Graph Layouts</h3>
     <%= image_tag("gephi-2.png", alt: "The import page for the Gephi application", class:"body_img")%>
     <p class="about_p">You'll now see the following basic layout in the Overview tab. Not too useful, is it? Let's begin by creating a new layout, which you'll see highlighted here below:</p>
     <%= image_tag("gephi-3.png", alt: "A basic layout in Gephi", class:"body_img")%>
@@ -35,8 +45,9 @@
     <p class="about_p">Some of the labels now overlap, so let's run another simple "layout." This time, we select "Label Adjust" and press run.</p>
     <%= image_tag("gephi-8.png", alt: "Label adjust", class:"body_img")%>
     <p class="about_p">We now have a pretty decently laid out network!</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Applying a Statistical Analysis</h3>
+    <h3 class="about_h3" id="4toc">Applying a Statistical Analysis</h3>
     <p class="about_p">Now let's run a statistical analysis. We'll run a rudimentary community detection algorithm. We can find that in the "statistics" section on the right hand side. Click the "run" button next to modularity, and click through the next report. The two following screenshots show you where to look.</p>
     <%= image_tag("gephi-9.png", alt: "Modularity class one", class:"body_img")%>
     <%= image_tag("gephi-10.png", alt: "Modularity class two", class:"body_img")%>
@@ -46,5 +57,6 @@
     <p class="about_p">At the end of this lesson, your graph should be looking quite a bit like this:</p>
     <%= image_tag("gephi-12.png", alt: "Final layout", class:"body_img")%>
     <p class="about_p">Congratulations! You now have a nicely-laid out graph. Try experimenting with other features in Gephi now. If you want to see a fully-fleshed out example of using Gephi with research, please read on to the <%=link_to("Network Graphing Archived Websites With Gephi", "/derivatives/gephi")%> lesson.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
   </div>
 <% end %>

--- a/app/views/pages/basic-gephi.html.erb
+++ b/app/views/pages/basic-gephi.html.erb
@@ -12,7 +12,7 @@
           <li class="toc-li"><%=link_to('Applying a Statistical Analysis', anchor: '4toc') %></li>
         </ul>
     </div>
-    <br>
+    <br />
     <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">This is a very basic introduction to Gephi. It begins with the assumption of no knowledge around Gephi, and explains how you can import the file you receive from AUK and do some basic transformations on it yourself.</p>
     <p class="about_p">While your graphs have some basic characteristics computed for them, you may want to start from fresh and learn some of the basics.</p>

--- a/app/views/pages/derivatives.html.erb
+++ b/app/views/pages/derivatives.html.erb
@@ -154,6 +154,8 @@
       </div>
     </div>
     <br />
+    <h3 class="about_h3">Case Studies</h3>
+    <p class="about_p"></p>
     <h3 class="about_h3">How to Cite Archives Unleashed</h3>
     <p class="about_p">If you've found the Archives Unleashed Toolkit or Cloud helpful in your research, please consider using the citation below in your publications. Your citations help to further the recognition of using open-source tools for scientific inquiry, assists in growing the web archiving community, and acknowledges the efforts of contributors to this project.
     <p class="about_p">Archives Unleashed Project. (2018). Archives Unleashed Toolkit (Version 0.16.0). Apache License, Version 2.0.</p>

--- a/app/views/pages/derivatives.html.erb
+++ b/app/views/pages/derivatives.html.erb
@@ -154,8 +154,6 @@
       </div>
     </div>
     <br />
-    <h3 class="about_h3">Case Studies</h3>
-    <p class="about_p"></p>
     <h3 class="about_h3">How to Cite Archives Unleashed</h3>
     <p class="about_p">If you've found the Archives Unleashed Toolkit or Cloud helpful in your research, please consider using the citation below in your publications. Your citations help to further the recognition of using open-source tools for scientific inquiry, assists in growing the web archiving community, and acknowledges the efforts of contributors to this project.
     <p class="about_p">Archives Unleashed Project. (2018). Archives Unleashed Toolkit (Version 0.16.0). Apache License, Version 2.0.</p>

--- a/app/views/pages/domains.html.erb
+++ b/app/views/pages/domains.html.erb
@@ -13,7 +13,7 @@
           <li class="toc-li"><%=link_to('The domain derivative download', anchor: '5toc') %></li>
         </ul>
     </div>
-    <br>
+    <br />
     <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">We don't always know exactly what we've collected in our web archives, or as researchers, what we'll find inside a given collection. The web is a complex beast: a small web archive that aims to collect just one page might end up capturing embedded widgets and content from other websites just to make something play; alternatively, a crawl might have been corrupted and begun to find material that's far out of scope.</p>
     <p class="about_p">This tutorial explores what you can learn from the derivative file marked as "Domains" in your collections page, as well as the list of domains that are displayed right on the page itself.</p>

--- a/app/views/pages/domains.html.erb
+++ b/app/views/pages/domains.html.erb
@@ -4,13 +4,23 @@
   <div class="container">
     <h1 class="about_h1">Making Sense of the Domains Count</h1>
     <p class="about_p_italic">Tutorial by Ian Milligan (Archives Unleashed Team)</p>
-
-    <h3 class="about_h3">Introduction</h3>
+    <div class="toc">
+        <ul class="toc_list">
+          <li class="toc-li"><%=link_to('Introduction', anchor: '1toc') %></li>
+          <li class="toc-li"><%=link_to('What do we mean by domain frequency?', anchor: '2toc') %></li>
+          <li class="toc-li"><%=link_to('What can you learn from this sort of information?', anchor: '3toc') %></li>
+          <li class="toc-li"><%=link_to('The domain chart', anchor: '4toc') %></li>
+          <li class="toc-li"><%=link_to('The domain derivative download', anchor: '5toc') %></li>
+        </ul>
+    </div>
+    <br>
+    <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">We don't always know exactly what we've collected in our web archives, or as researchers, what we'll find inside a given collection. The web is a complex beast: a small web archive that aims to collect just one page might end up capturing embedded widgets and content from other websites just to make something play; alternatively, a crawl might have been corrupted and begun to find material that's far out of scope.</p>
     <p class="about_p">This tutorial explores what you can learn from the derivative file marked as "Domains" in your collections page, as well as the list of domains that are displayed right on the page itself.</p>
     <%= image_tag("Tutorial_domains.png", alt: "The download icon for domain counts as well as the top ten on the collection page", class:"body_img")%>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">What do we mean by domain frequency?</h3>
+    <h3 class="about_h3" id="2toc">What do we mean by domain frequency?</h3>
     <p class="about_p">The "domains" derivative provides a <strong>frequency count of the domains that have been captured by a web archive</strong>. Imagine a web archive that has five pages captured:</p>
     <ul class="about_ul">
       <li class="about_li">liberal.ca</li>
@@ -24,8 +34,9 @@
       <li class="about_li">liberal.ca, 3</li>
       <li class="about_li">greenparty.ca, 2</li>
     </ul>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">What can you learn from this sort of information?</h3>
+    <h3 class="about_h3" id="3toc">What can you learn from this sort of information?</h3>
     <p class="about_p">Imagine a few things that you might learn just by seeing the frequency of domains that have been collected:</p>
     <ul class="about_ul">
       <li class="about_li"><strong>The crawl contains certain kinds of sites</strong>. At a glance you can begin to explore questions such as whether a web archive is primarily composed of social media (say lots of occurrences of twitter.com and facebook.com)? Or is it a media archive (NewYorkTimes.com and GlobeandMail.com make up a large amount of it)? Or something else. Given the unevenness of some metadata, sometimes just seeing what has been collected is what you need to get a sense of a collection.</li>
@@ -33,18 +44,21 @@
       <li class="about_li"><strong>The web crawl has remained small and focused</strong>. Imagine a web archive that only has a few sites. They've been collected a few times. This means that the crawl has maintained focus on a small number of websites, and if you decide to subsequently work with the plain text or network graphs, you can interpret the results accordingly.</li>
     </ul>
     <p class="about_p">There are many other things you can learn from this information, of course, these are just a few.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">The domain chart</h3>
+    <h3 class="about_h3" id="4toc">The domain chart</h3>
     <p class="about_p">On each of our collection landing pages, we provide a frequency table to identify the <strong>top ten domains represented within each collection</strong>. By default, these are presented in declining order: the most frequently-collected domain at the top and the tenth-most frequently-collected domain at the bottom.</p>
     <p class="about_p">For a lot of users, this is probably going to be enough! You get a sense of the major sites and nodes of collections. For example, consider the output for the "Nova Scotia Municipal Governments" collection.</p>
     <%= image_tag("Tutorial_domain_chart.png", alt: "Top ten domains as presented on collection page", class:"body_img")%>
     <p class="about_p">Here we learn that the sites that are being collected are municipal government sites, as opposed to media outlets about municipal government sites, or research projects about governments that are being carried out at a university.</p>
     <p class="about_p">However, we only see the top ten. Sometimes we might need to be more granular and see beyond these.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">The domain derivative download</h3>
+    <h3 class="about_h3" id="5toc">The domain derivative download</h3>
     <p class="about_p">By clicking on the "Domains" button, users are provided with a text file that will be named something like 7485-fullurls.txt. You can open this file up in your text editor of choice. By default on MacOS, it will open in TextEdit and look like this:</p>
     <%= image_tag("Tutorial_domain_derivative_file.png", alt: "Screenshot of the domain derivative file in MacOS TextEdit", class:"body_img")%>
     <p class="about_p">Here we see our suspicions confirmed! The sites are all indeed Nova Scotian municipal governments, which are identified by the .ns.ca in the URL. Here we are already beginning to learn the relative sizes of the collection.</p>
     <p class="about_p">This will help support future analysis – if a collection contains a given website thousands of times, you need to keep that in mind when doing text analysis. If it only appears a fraction of what some of the other sites are doing, even if it is important it might be drowned out by all of the other information within an archive.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
   </div>
 <% end %>

--- a/app/views/pages/gephi.html.erb
+++ b/app/views/pages/gephi.html.erb
@@ -15,7 +15,7 @@
           <li class="toc-li"><%=link_to('Taking Your Graph Outside of Gephi', anchor: '7toc') %></li>
         </ul>
     </div>
-    <br>
+    <br />
     <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">When using the web as a historical source, the ability to see the way websites link to each other can be invaluable. However, using network analysis in historical research can also be a daunting prospect. The creation and interpretation of network graphs requires new tools and methodologies which may be unfamiliar to historians and other humanities scholars. Increasingly, tools such as the Archives Unleashed Cloud are making large datasets easily available for historical research using web sources. However, what do you do with this data once you have it?</p>
     <%= image_tag("Tutorial_icons.png", alt: "The derivative download buttons with the Gephi one highlighted", class:"body_small_img")%>

--- a/app/views/pages/gephi.html.erb
+++ b/app/views/pages/gephi.html.erb
@@ -4,23 +4,37 @@
   <div class="container">
     <h1 class="about_h1">Network Graphing Archived Websites With Gephi</h1>
     <p class="about_p_italic">Tutorial by Sarah McTavish (PhD Candidate, University of Waterloo)</p>
-
-    <h3 class="about_h3">Introduction</h3>
+    <div class="toc">
+        <ul class="toc_list">
+          <li class="toc-li"><%=link_to('Introduction', anchor: '1toc') %></li>
+          <li class="toc-li"><%=link_to('Getting Started', anchor: '2toc') %></li>
+          <li class="toc-li"><%=link_to('Example in this Tutorial', anchor: '3toc') %></li>
+          <li class="toc-li"><%=link_to('Loading Your Data into Gephi', anchor: '4toc') %></li>
+          <li class="toc-li"><%=link_to('Sorting and Graphing Your Data', anchor: '5toc') %></li>
+          <li class="toc-li"><%=link_to('Filtering Your Data', anchor: '6toc') %></li>
+          <li class="toc-li"><%=link_to('Taking Your Graph Outside of Gephi', anchor: '7toc') %></li>
+        </ul>
+    </div>
+    <br>
+    <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">When using the web as a historical source, the ability to see the way websites link to each other can be invaluable. However, using network analysis in historical research can also be a daunting prospect. The creation and interpretation of network graphs requires new tools and methodologies which may be unfamiliar to historians and other humanities scholars. Increasingly, tools such as the Archives Unleashed Cloud are making large datasets easily available for historical research using web sources. However, what do you do with this data once you have it?</p>
     <%= image_tag("Tutorial_icons.png", alt: "The derivative download buttons with the Gephi one highlighted", class:"body_small_img")%>
     <p class="about_p">This tutorial explores what you can learn from the derivative file marked as "Gephi" or "Raw Network" in your collections page.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Getting Started</h3>
+    <h3 class="about_h3" id="2toc">Getting Started</h3>
     <p class="about_p">There are several tools and methods for interpreting and visualizing large datasets; some require coding knowledge. However open-source network graphing software, such as Gephi, allow users to sort, filter, and graph data using a simple visual interface. Gephi can be downloaded for free for Windows, MacOS, and Linux from <%= link_to('this website','https://gephi.org/', target: '_blank') %>.</p>
     <%= image_tag("Tutorial_Gephi.png", alt: "Screenshot of gephi.org to show where to download Gephi", class:"body_img")%>
     <p class="about_p">Once installed, you can either generate graphs from a spreadsheet, or other graph file formats, in order to manipulate their data. Using a GraphML file generated from the Archives Unleashed Cloud, I will demonstrate how to analyze a network graph using Gephi.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Example in this Tutorial</h3>
+    <h3 class="about_h3" id="3toc">Example in this Tutorial</h3>
     <p class="about_p">In this example, we will be graphing the University of Alberta's "Fort McMurray Wildfires" collection, in order to explore where people were getting their information from during this significant Canadian news event. These northern Alberta wildfires took place during early May 2016, and resulted in the evacuation of nearly 90,000 residents. The fires spread quickly over several days, leading to dramatic photographs and video footage of residents fleeing their homes as the fires engulfed parts of the city and the surrounding area. The nature of the wildfires and evacuation sparked considerable media attention worldwide.</p>
     <p class="about_p">This international interest compounded the expected online coverage from local and regional residents and officials, who used the internet to spread necessary information on evacuation efforts and the state of the city during the fires. But which online news sources did people use to learn about the wildfires?  Were official government websites linked to more frequently than the mainstream media?  What role did blogs and social media play?  By visualizing the linkages between sites crawled and archived during the media coverage of the wildfires, we can see which news sources were most relevant to people looking for information and which sites were linked to most frequently.</p>
     <p class="about_p">This example uses data from the <%= link_to('Web Archives for Longitudinal Knowledge project','https://uwaterloo.ca/web-archive-group/news/compute-canada-grant-web-archives-longitudinal-knowledge', target: '_blank') %>. We took the collections of six Canadian university libraries -- the Universities of Toronto, Alberta, Manitoba, Victoria, Simon Fraser University, and Dalhousie -- and among other things generated derivative datasets (like what you get from the Archives Unleashed Cloud). You will soon be able to download separately all of the network diagrams from these collections to use as a sample example.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Loading Your Data into Gephi</h3>
+    <h3 class="about_h3" id="4toc">Loading Your Data into Gephi</h3>
     <p class="about_p">The downloaded .graphml file can be opened directly in Gephi by choosing "Open Graph File" from the Gephi startup screen and then selecting the file to be opened.</p>
     <p class="about_p">Note that if you are using Safari, the file may come with an extra <code>.xml</code> extension added to it (i.e. it will read <code>9745-gephi.gexf.xml</code>). You will need rename the file to remove <code>.xml</code>. The file should end with <code>.gexf</code>.</p>
     <%= image_tag("Tutorial_OpenFile.png", alt: "The dialog box from Gephi showing how to open a graph file", class:"body_img")%>
@@ -29,8 +43,9 @@
     <p class="about_p">Gephi also provides a Data Laboratory view, which provides a list of all of the nodes, with all of their relevant statistics. It is in this view that the dataset can be manipulated; individual nodes can be deleted, the data can be sorted according to variables such as how frequently the node is linked to, and the labels for the data points can be changed. You can find that by clicking the "Data Laboratory" button at the upper left of the program.</p>
     <%= image_tag("Tutorial_datalab.png", alt: "The Gephi data laboratory view highlighted", class:"body_img")%>
     <p class="about_p">Now let's begin exploring our data.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Sorting and Graphing Your Data</h3>
+    <h3 class="about_h3" id="5toc">Sorting and Graphing Your Data</h3>
     <p class="about_p">Going back to the "Overview" tab, we can then begin sorting and filtering our data. On the right side of the screen, Gephi's Filters and Statistics toolbar provides some simple but powerful tools to determine which variables will be used to graph the data, and which data points will be included. Under statistics, there is a list of algorithms that can be used in order to sort the data.</p>
      <ul class="about_ul">
       <li class="about_li"><strong><%= link_to('Average Clustering Coefficient','https://github.com/gephi/gephi/wiki/Average-Clustering-Coefficient', target: '_blank') %></strong> - The measure of how "complete" the neighbourhood or a node is. In a network where every node is connected to every other node, the clustering coefficient will be 1. If no nodes are connected to any other nodes, the clustering coefficient will be 0.</li>
@@ -66,8 +81,9 @@
     <p class="about_p">By looking at the network graph, it becomes apparent that social media, such as Twitter, Facebook, and Instagram, played a central role in directing how users found information about the wildfires. This is perhaps not a surprising result. However, we can also see the reciprocal linking between official government web pages, such as Alberta.ca, and social media, but not more traditional news sources; this provides a fascinating perspective on the ways that information was disseminated from official sources in during the 2016 wildfires. Furthermore, we see distinct clusters of online and traditional news media, which show patterns of interaction and connection.</p>
     <%= image_tag("Tutorial_highlight.png", alt: "A Gephi network with Macleans.com highlighted, showing how it is linked to other mainstream media sources.", class:"body_img")%>
     <p class="about_p">To help see these clusters even more clearly, you can hover your mouse cursor over one of the nodes. For example, here we have selected the "Macleans" news magazine's website --- we can see connections to other traditional Canadian news media outlets such as the <em>National Post</em> and <em>Globe and Mail</em> newspapers.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Filtering Your Data</h3>
+    <h3 class="about_h3" id="6toc">Filtering Your Data</h3>
     <p class="about_p">Gephi also provides a useful set of tools for filtering data according to a number of variables. When working with many large datasets, it may be necessary to filter the data down to a smaller number of nodes, in order to provide useful visualizations. In short, filtering removes a lot of the "clutter" in the network graphs, in order to allow places of significance to show through clearly and quickly. Depending on need, the graph could be filtered using the edge tools, showing only sites with reciprocal linking, or one way linking, for example. These filters are found on the right-hand toolbar, under the Filters tab.</p>
     <p class="about_p">For this graph, I've filtered according to Degree Range, removing all sites that don't link to at least two other sites. This removes a lot of the "cloud" of sites that appears at the edges of the network, but are not highly interconnected within the network. However, we also lose distinct clusters, such as the one that appears in purple in the upper right corner of the graph; these sites only link to one site within our network, but the existence of these clusters could be a place for further exploration. Filtering can be incredibly important and necessary in order to comprehend the network as a whole, but can lead to a loss of nuance within the network.</p>
     <p class="about_p_center"><iframe width="560" height="315" src="https://www.youtube.com/embed/lGMSwz98nmI" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe></p>
@@ -78,11 +94,14 @@
       <li class="about_li">The filter parameters will appear at the bottom of the change. The slider can be dragged to adjust the filter. In this example, I set the minimum degree to "2" in order to filter out all sites that don't link to at least two other sites.</li>
       <li class="about_li">Click on the "Start" button to begin filtering. Clicking "Stop" will restore all of the filtered sites.</li>
     </ol>
-    <h3 class="about_h3">Taking Your Graph Outside of Gephi</h3>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
+
+    <h3 class="about_h3" id="7toc">Taking Your Graph Outside of Gephi</h3>
     <p class="about_p">Lastly, Gephi provides preview and export tools which make it easy to include a network graph in a paper or presentation. Users can change the appearance of the graph to suit their needs, and then export it as a PNG or PDF file. This tool is found under the "Preview" button, to the top left of the screen.</p>
     <%= image_tag("Tutorial_preview.png", alt: "The main page of Gephi with the Preview tab highlighted", class:"body_img")%>
     <p class="about_p">Label sizes and node appearance can all be changed on the preview toolbar to the left of the screen. It is necessary to click the "Refresh" button to view changes. The image of the graph can then be saved by clicking "Export SVG/PDF/PNG" near the bottom left of the screen.</p>
     <%= image_tag("Tutorial_download.png", alt: "The popup screen showing how to Export a file as a PDF", class:"body_img")%>
     <p class="about_p">Using Gephi, it is a simple task to generate network graphs using archived web collections. Gephi's powerful and diverse range of tools and algorithms allow data to be manipulated and visualized in order to highlight the interconnection between archived websites. These graphs allow for new perspectives on influence and interaction when doing historical research with archived web materials.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
   </div>
 <% end %>

--- a/app/views/pages/text-antconc.html.erb
+++ b/app/views/pages/text-antconc.html.erb
@@ -4,23 +4,36 @@
  <div class="container">
   <h1 class="about_h1">Text Analysis Part One: Beyond the Keyword Search: Using AntConc</h1>
   <p class="about_p_italic">Tutorial by Sarah McTavish (PhD Candidate, University of Waterloo)</p>
-
-  <h3 class="about_h3">Introduction</h3>
+  <div class="toc">
+        <ul class="toc_list">
+          <li class="toc-li"><%=link_to('Introduction', anchor: '1toc') %></li>
+          <li class="toc-li"><%=link_to('Beyond the Keyword Search: Using AntConc for Text Analysis', anchor: '2toc') %></li>
+          <li class="toc-li"><%=link_to('Loading Our Data', anchor: '3toc') %></li>
+          <li class="toc-li"><%=link_to('Using AntConc to Examine Concordances and Collocates', anchor: '4toc') %></li>
+          <li class="toc-li"><%=link_to('Conclusion', anchor: '5toc') %></li>
+        </ul>
+    </div>
+    <br>
+  <h3 class="about_h3" id="1toc">Introduction</h3>
   <p class="about_p">In my own research using thousands of deleted webpages as a historical source, the Wayback Machine has been an invaluable tool for viewing these sites as they were originally presented. With thousands of personal webpages, photos, journals, and biographies found within web archives, the temptation to just keep reading forever is high. However, there are limits to what one human can read. The alternative to endless link-clicking is large scale text analysis. But how can we make any more sense of a massive text file than a large collection of websites on the Wayback Machine?</p>
   <p class="about_p">Web archives are very big. For example, my own research uses a GeoCities "neighbourhood" which was intended to house gay, lesbian, and transgender personal webpages, and contains approximately 25,000 individual user sites. Just the raw text from WestHollywood is 1.7 gigabytes, much more than I could possibly read in my lifetime, despite sometimes wishing that it was possible. How can I make sense of this enormous collection of archived web pages? What types of large scale text analysis can be most useful in tackling this kind of source base? This tutorial walks you through an easy-to-use tool, Antconc, which can help you explore the text of an archived webpage.</p>
-  <h3 class="about_h3">Beyond the Keyword Search: Using AntConc for Text Analysis</h3>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
+
+  <h3 class="about_h3" id="2toc">Beyond the Keyword Search: Using AntConc for Text Analysis</h3>
   <p class="about_p">AntConc is free corpus analysis software that can be <%= link_to('downloaded for Windows, Mac, and Linux', 'http://www.laurenceanthony.net/software/antconc/', target: '_blank') %>. Using AntCont, it is possible to investigate concordances in your text, without having any coding knowledge.</p>
   <%= image_tag("Tutorial_antconc.png", alt: "AntConc can be downloaded from laurenceanthony.net/software.html", class:"body_img")%>
   <p class="about_p">After installing AntConc, choose "Open File" or "Open Dir" (to open a directory containing multiple text files) from the File menu to begin analyzing your text files. Files must be in a .txt format, with UTF-8 formatting. If your file is in a different format, the creator of AntConc also offers file converter and encoding software, which can be <%= link_to('downloaded for free from this website', 'http://www.laurenceanthony.net/software.html', target: '_blank') %>.</p>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-  <h3 class="about_h3">Loading Our Data</h3>
+  <h3 class="about_h3" id="3toc">Loading Our Data</h3>
   <p class="about_p">In this tutorial, I will be working with the University of Alberta's Fort McMurray Wildfires Collection. These northern Alberta wildfires took place during early May 2016, and resulted in the evacuation of nearly 90 000 residents. The fires spread quickly over several days, leading to dramatic photographs and video footage of residents fleeing their homes as the fires engulfed parts of the city and the surrounding area.</p>
   <p class="about_p">The dramatic nature of the wildfires and evacuation sparked considerable media attention worldwide. This international interest compounded the expected online coverage from local and regional residents and officials, who used the internet to spread necessary information on evacuation efforts and the state of the city during the fires. The Fort McMurray Wildfires Collection contains sites crawled and collected during coverage of these wildfires; for the purposes of this tutorial, we will be using a raw text version of this collection, which is 2.6 gigabytes in size. Using AntConc, we can examine the most frequently-used words in the collection, the context that they appear in, and the words most frequently found in relation to a given keyword.</p>
   <p class="about_p">AntConc handles many smaller files much better than one large text file, so it may be helpful to <%= link_to('split the file into multiple smaller files', 'https://stackoverflow.com/questions/2016894/how-to-split-a-large-text-file-into-smaller-files-with-equal-number-of-lines', target: '_blank') %> and try running those through instead. When running large files, AntConc has a tendency to freeze and crash; this problem is eliminated by breaking the data into many smaller files. To do so requires the command line, which you can find a tutorial about <%= link_to('here', 'https://programminghistorian.org/en/lessons/intro-to-bash', target: '_blank') %>. For the Fort McMurray all-text file, I split the 2.6 gigabyte file into 314 files of 2000 lines each. Using the Terminal, I navigated to the directory with the plain text file downloaded into it and entered the command:</p>
   <p class="about_p"><code>split -l 2000 7368-fulltext.txt</code></p>
   <p class="about_p">This splits the file into multiple files, each 2000 lines in size -- these files are named <code>xaa</code>, <code>xab</code>, <code>xac</code>, etc. I then moved all of these files (you can use your file explorer) to a new folder, named <code>FMMWildfiresSplit</code>.</p>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-  <h3 class="about_h3">Using AntConc to Examine Concordances and Collocates</h3>
+  <h3 class="about_h3" id="4toc">Using AntConc to Examine Concordances and Collocates</h3>
   <p class="about_p">Using "Open Dir" from the "File" menu, we're going to choose the <code>FMMWildfiresSplit</code> directory. This loads all 314 text files into AntConc.</p>
   <p class="about_p">A search under the "Concordance" tab will find every instance of a word of phrase, and display it in context with several words to the right and left of it. In this example, I did a search for "oil sands," which should be highly prevalent when examining the new coverage surrounding the wildfires, which took place in an area dominated by the oil extraction industry. After sorting through my 314 text files, AntConc found 83 888 uses of the words "oil sands" in the collection, and displays them with their contexts.</p>
   <%= image_tag("Tutorial_concordances.png", alt: "We can use AntConc to find all instances of the words 'oil sands' in our text", class:"body_img")%>
@@ -29,6 +42,10 @@
   <%= image_tag("Tutorial_collocates.png", alt: "AntConc can also generate lists of collocates, words that appear within several words of our search term", class:"body_img")%>
   <p class="about_p">Perhaps even more usefully, AntConc allows you to click on any collocate, and will show all concordances of that word along with your search term. Using this method, it is possible to view all instances of two related words within your text source. If you already know the word that you are looking for in relation to your search term, you can also do this directly through the Concordance tab, using AntConc's advanced search tools. The other benefit is that you can create a context word list, in order to further tailor your search results according to multiple context words. However, this requires you to already know the specific context and search terms that you expect to see; for this, it can be helpful to first run Collocation to view the most frequently-used words.</p>
   <%= image_tag("Tutorial_antconc_search.png", alt: "Using AntConc's advanced search options", class:"body_img")%>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
+
+  <h3 class="about_h3" id="5toc">Conclusion</h3>
   <p class="about_p">Overall, AntConc provides rather surface analysis on text sources, by looking at the instance of a named search term, and the context within which that word is found. However, this type of analysis can be incredibly useful for dealing with situations where keyword searches yield too many results to be meaningfully read, or to determine the context around which a search term is found. By combining search terms, it is possible to whittle thousands of keyword results down to a few dozen relevant matches.</p>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
  </div>
 <% end %>

--- a/app/views/pages/text-antconc.html.erb
+++ b/app/views/pages/text-antconc.html.erb
@@ -13,7 +13,7 @@
           <li class="toc-li"><%=link_to('Conclusion', anchor: '5toc') %></li>
         </ul>
   </div>
-    <br>
+  <br />
   <h3 class="about_h3" id="1toc">Introduction</h3>
   <p class="about_p">In my own research using thousands of deleted webpages as a historical source, the Wayback Machine has been an invaluable tool for viewing these sites as they were originally presented. With thousands of personal webpages, photos, journals, and biographies found within web archives, the temptation to just keep reading forever is high. However, there are limits to what one human can read. The alternative to endless link-clicking is large scale text analysis. But how can we make any more sense of a massive text file than a large collection of websites on the Wayback Machine?</p>
   <p class="about_p">Web archives are very big. For example, my own research uses a GeoCities "neighbourhood" which was intended to house gay, lesbian, and transgender personal webpages, and contains approximately 25,000 individual user sites. Just the raw text from WestHollywood is 1.7 gigabytes, much more than I could possibly read in my lifetime, despite sometimes wishing that it was possible. How can I make sense of this enormous collection of archived web pages? What types of large scale text analysis can be most useful in tackling this kind of source base? This tutorial walks you through an easy-to-use tool, Antconc, which can help you explore the text of an archived webpage.</p>

--- a/app/views/pages/text-antconc.html.erb
+++ b/app/views/pages/text-antconc.html.erb
@@ -12,7 +12,7 @@
           <li class="toc-li"><%=link_to('Using AntConc to Examine Concordances and Collocates', anchor: '4toc') %></li>
           <li class="toc-li"><%=link_to('Conclusion', anchor: '5toc') %></li>
         </ul>
-    </div>
+  </div>
     <br>
   <h3 class="about_h3" id="1toc">Introduction</h3>
   <p class="about_p">In my own research using thousands of deleted webpages as a historical source, the Wayback Machine has been an invaluable tool for viewing these sites as they were originally presented. With thousands of personal webpages, photos, journals, and biographies found within web archives, the temptation to just keep reading forever is high. However, there are limits to what one human can read. The alternative to endless link-clicking is large scale text analysis. But how can we make any more sense of a massive text file than a large collection of websites on the Wayback Machine?</p>

--- a/app/views/pages/text-filtering.html.erb
+++ b/app/views/pages/text-filtering.html.erb
@@ -4,8 +4,19 @@
   <div class="container">
     <h1 class="about_h1">Filtering the Full-Text Derivative File</h1>
     <p class="about_p_italic">Tutorial by Ian Milligan (Archives Unleashed Team)</p>
-
-    <h3 class="about_h3">Introduction</h3>
+    <div class="toc">
+        <ul class="toc_list">
+          <li class="toc-li"><%=link_to('Introduction', anchor: '1toc') %></li>
+          <li class="toc-li"><%=link_to('Using Grep', anchor: '2toc') %></li>
+          <li class="toc-li"><%=link_to('A Command Line Example: Finding the Derivatives', anchor: '3toc') %></li>
+          <li class="toc-li"><%=link_to('Finding Dates', anchor: '4toc') %></li>
+          <li class="toc-li"><%=link_to('Finding Specific Domains', anchor: '5toc') %></li>
+          <li class="toc-li"><%=link_to('Finding Keywords', anchor: '6toc') %></li>
+          <li class="toc-li"><%=link_to('Conclusion', anchor: '7toc') %></li>
+        </ul>
+    </div>
+    <br>
+    <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">We have some filtering tools already built into the Archives Unleashed Cloud -- for example, the "Text by Domain" button will give you a zip file of the text of the top ten domains within a web archive. Yet you may want to filter the derivative files further, so that they for example:</p>
     <ul class="about_ul">
       <li class="about_li">Only contain websites from a certain date (i.e. all sites collected on July 16th, 2009)</li>
@@ -13,13 +24,15 @@
       <li class="about_li">Only contain websites that have a certain keyword (i.e. every page that contains the word "elephant")</li>
     </ul>
     <p class="about_p">Fortunately, you can easily do this with some simple tools.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Using Grep</h3>
+    <h3 class="about_h3" id="2toc">Using Grep</h3>
     <p class="about_p"><%= link_to('Grep','https://www.gnu.org/software/grep/manual/grep.html', target: '_blank') %> is a Unix utility that stands for "globally search a regular expression and print." In short, it lets you take a text file and find lines that match criteria that you specify. Grep is especially useful for working with the files that the Cloud generates because each line in the full-text file corresponds to one website in the collection.</p>
     <p class="about_p">If you are on Linux or MacOS, you have Grep already installed. If you're on Windows, you will need to install a program called "Git Bash." You will want to find the "full installer" <%= link_to('here','https://git-for-windows.github.io/', target: '_blank') %>, and follow <%= link_to('these instructions to install','https://openhatch.org/missions/windows-setup/install-git-bash', target: '_blank') %>.</p>
     <p class="about_p">The command line is powerful, but not always straightforward. Fortunately, there is a good walkthrough at the Programming Historian: <%= link_to('Introduction to Bash','https://programminghistorian.org/en/lessons/intro-to-bash', target: '_blank') %>. For the purposes of this tutorial, you will want to be able to "find" files in the command line.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">A Command Line Example: Finding the Derivatives</h3>
+    <h3 class="about_h3" id="3toc">A Command Line Example: Finding the Derivatives</h3>
     <p class="about_p">In addition to the resources above, an example might give you a sense of how relatively straightforward it can be to locate files. Imagine that in the Cloud interface, you download the "full text" file. On MacOS, this defaults to your "downloads" directory.</p>
     <p class="about_p">To open the command line on MacOS, we go to our "Applications" folder, "Utilities," and then select "Terminal." You will see this window (your colours might be different):</p>
     <%= image_tag("tutorial_terminal.png", alt: "Screenshot of a terminal window", class:"body_img")%>
@@ -28,8 +41,9 @@
     <p class="about_p">If you type:</p>
     <p class="about_p"><code>ls</code></p>
     <p class="about_p">You will then see a long list of all of the files in this directory. Amongst them should be the file you downloaded from the Cloud! You could begin working on it here, or you could move it somewhere else on your file system. For more information on this, see the Bash tutorial above.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Finding Dates</h3>
+    <h3 class="about_h3" id="4toc">Finding Dates</h3>
     <p class="about_p">In the following example, I will use the files from the "Fort McMurray" collection. You can follow along with your own files, simply changing the collection number to your own (i.e. instead of 7368-fulltext.txt it might be 1234-fulltext.txt).</p>
     <p class="about_p">Let's imagine that we have a collection, but we just want part of it: in this case, the sites that match a certain date. This won't necessarily be the date that sites were created but will instead be the date that sites were crawled.</p>
     <p class="about_p">To do so, let's take a look at the basic structure of the full text file. We can do so by either opening up the file in a text editor, or in the command line, we can type a command that shows us the first x lines of a file.</p>
@@ -46,21 +60,24 @@
     <p class="about_p">The basic structure of this command is:</p>
     <p class="about_p"><code>grep PATTERN FILE-TO-ANALYZE > FILEOUTPUT.TXT</code></p>
     <p class="about_p">So in this case for the pattern, the quotation marks enclose the pattern we are looking for. <code>^</code> represents the "start of the line," and then since there is an opening parenthesis we look for that too. We then provide an output path for the results. In this case, there will now be a new file – 20160522-text.txt – that just contains the crawl text from 22 May 2016.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Finding Specific Domains</h3>
+    <h3 class="about_h3" id="5toc">Finding Specific Domains</h3>
     <p class="about_p">If the domain is in the top ten, you can use our handy "text by domain" derivative to work with it out of the box. If you want to find a different domain, however, you may have to do a bit of work yourself.</p>
     <p class="about_p">The logic is similar to finding specific domains. We'll also use grep. In the example above, we saw two different domains. Let's use "www.rmwb.ca" as our example and get only websites from that domain.</p>
     <p class="about_p">We turn to grep again:</p>
     <p class="about_p"><code>grep ',www.rmwb.ca,' 7368-fulltext.txt > RMWB-text.txt</code></p>
     <p class="about_p">We now have a text file that just contains websites from the "www.rmwb.ca" domain.</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Finding Keywords</h3>
+    <h3 class="about_h3" id="6toc">Finding Keywords</h3>
     <p class="about_p">And of course, things are relatively similar with keywords. This can be the easiest one.</p>
     <p class="about_p"><code>grep 'helicopter' 7368-fulltext.txt > helicopter-text.txt</code></p>
     <p class="about_p">We now just have the text of all websites that contain the word "helicopter."</p>
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-    <h3 class="about_h3">Conclusion</h3>
+    <h3 class="about_h3" id="7toc">Conclusion</h3>
     <p class="about_p">These relatively straightforward commands need a bit of practice, but before you know it, you'll be filtering your web archive files like an expert. You can then move on to subsequent analysis steps, or if it's small enough, maybe even just start reading.</p>
-
+    <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
   </div>
 <% end %>

--- a/app/views/pages/text-filtering.html.erb
+++ b/app/views/pages/text-filtering.html.erb
@@ -15,7 +15,7 @@
           <li class="toc-li"><%=link_to('Conclusion', anchor: '7toc') %></li>
         </ul>
     </div>
-    <br>
+    <br />
     <h3 class="about_h3" id="1toc">Introduction</h3>
     <p class="about_p">We have some filtering tools already built into the Archives Unleashed Cloud -- for example, the "Text by Domain" button will give you a zip file of the text of the top ten domains within a web archive. Yet you may want to filter the derivative files further, so that they for example:</p>
     <ul class="about_ul">

--- a/app/views/pages/text-sentiment.html.erb
+++ b/app/views/pages/text-sentiment.html.erb
@@ -13,7 +13,7 @@
           <li class="toc-li"><%=link_to('What Can We Learn From Sentiment Analysis?', anchor: '5toc') %></li>
         </ul>
   </div>
-  <br>
+  <br />
   <h3 class="about_h3" id="1toc">Introduction</h3>
   <p class="about_p">In Part 1 (link here), we examined how we can use text analysis software AntConc to investigate concordances and collocates in a large text file. This type of analysis is incredibly useful for examining keyword use, while maintaining the context within which the keyword appeared. In Part 2, we look at the use of the Python Natural Language Toolkit and how to do more complex <%= link_to('sentiment analysis', 'https://en.wikipedia.org/wiki/Sentiment_analysis', target: '_blank') %> on our large text source. With this type of analysis, we can calculate whether a word or phrase in our text is primarily positive, negative, or neutral. Sentiment analysis can shed light on the emotions expressed when discussing a given topic; when combined with other types of text analysis, such as that concordance and collation analysis, or combined with network analysis, sentiment analysis can be a powerful tool for bringing context to a large text source.</p>
   <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>

--- a/app/views/pages/text-sentiment.html.erb
+++ b/app/views/pages/text-sentiment.html.erb
@@ -4,14 +4,26 @@
  <div class="container">
   <h1 class="about_h1">Text Analysis Part Two: Sentiment Analysis With the Natural Language Toolkit</h1>
   <p class="about_p_italic">Tutorial by Sarah McTavish (PhD Candidate, University of Waterloo)</p>
-
-  <h3 class="about_h3">Introduction</h3>
+  <div class="toc">
+        <ul class="toc_list">
+          <li class="toc-li"><%=link_to('Introduction', anchor: '1toc') %></li>
+          <li class="toc-li"><%=link_to('Getting Started', anchor: '2toc') %></li>
+          <li class="toc-li"><%=link_to('Loading the Fort McMurray Wildfires Collection', anchor: '3toc') %></li>
+          <li class="toc-li"><%=link_to('Running NLTK in Jupyter Notebooks', anchor: '4toc') %></li>
+          <li class="toc-li"><%=link_to('What Can We Learn From Sentiment Analysis?', anchor: '5toc') %></li>
+        </ul>
+  </div>
+  <br>
+  <h3 class="about_h3" id="1toc">Introduction</h3>
   <p class="about_p">In Part 1 (link here), we examined how we can use text analysis software AntConc to investigate concordances and collocates in a large text file. This type of analysis is incredibly useful for examining keyword use, while maintaining the context within which the keyword appeared. In Part 2, we look at the use of the Python Natural Language Toolkit and how to do more complex <%= link_to('sentiment analysis', 'https://en.wikipedia.org/wiki/Sentiment_analysis', target: '_blank') %> on our large text source. With this type of analysis, we can calculate whether a word or phrase in our text is primarily positive, negative, or neutral. Sentiment analysis can shed light on the emotions expressed when discussing a given topic; when combined with other types of text analysis, such as that concordance and collation analysis, or combined with network analysis, sentiment analysis can be a powerful tool for bringing context to a large text source.</p>
-  <h3 class="about_h3">Getting Started</h3>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
+
+  <h3 class="about_h3" id="2toc">Getting Started</h3>
   <p class="about_p">In this tutorial, I use the web-based Jupyter Notebooks in the <%= link_to('Anaconda Navigator', 'https://www.anaconda.com/download/', target: '_blank') %> to write and run my code, instead of a text editor. Jupyter Notebooks helps keep all different parts and steps of a process in line, allows code to be ran directly in the editor, and makes it easy to share code with others. Using the Natural Language Toolkit (NLTK) requires some knowledge of coding in Python. The <%= link_to('NLTK Textbook', 'https://www.nltk.org/book/', target: '_blank') %> provides a lot of these basics in their codeface and chapter one, and it is worth working through their introductory exercises in order to get a feel for the code if you are a beginner to Python.</p>
   <p class="about_p">This tutorial builds on <%= link_to('this lesson', 'https://programminghistorian.org/en/lessons/sentiment-analysis', target: '_blank') %> on exploratory text analysis using sentiment analysis by Zoë Wilkinson Saldaña on The Programming Historian. This lesson explains how to load the NLTK libraries and perform sentiment analysis on sentence and paragraphs. You may find it useful to work through this lesson first, as it provides a good basis for working with smaller chunks of text, before moving on to larger text files.</p>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-  <h3 class="about_h3">Loading the Fort McMurray Wildfires Collection</h3>
+  <h3 class="about_h3" id="3toc">Loading the Fort McMurray Wildfires Collection</h3>
   <p class="about_p">In this tutorial, I will be working with the University of Alberta's Fort McMurray Wildfires Collection. These northern Alberta wildfires took place during early May 2016, and resulted in the evacuation of nearly 90 000 residents. The fires spreaded quickly over several days, leading to dramatic photographs and video footage of residents fleeing their homes as the fires engulfed parts of the city and the surrounding area.</p>
   <p class="about_p">The dramatic nature of the wildfires and evacuation sparked considerable media attention worldwide. This international interest compounded the expected online coverage from local and regional residents and officials, who used the internet to spread necessary information on evacuation efforts and the state of the city during the fires. The Fort McMurray Wildfires Collection contains sites crawled and collected during coverage of these wildfires; for the purposes of this tutorial, we will be using a raw text version of this collection, which is 2.6 gigabytes in size. By performing sentiment analysis on this text file, we can determine whether our chosen keywords appear more commonly in a positive, negative, or neutral context within this international media coverage.</p>
   <p class="about_p">These download files can be found in the Archives Unleashed Cloud's collection pages. See the button below.</p>
@@ -19,8 +31,9 @@
   <p class="about_p">In general, this type of analysis can handle files up to about 2 gigabytes in size. Because our file is 2.6 gigabytes, we'll have to split it into two. As with the previous tutorial, this requires the use of the command line. You can find a tutorial about how to use it <%= link_to('here', 'https://programminghistorian.org/en/lessons/intro-to-bash', target: '_blank') %>. Using the Terminal and navigating to the directory where I have downloaded the full text file, I enter the command:</p>
   <p class="about_p"><code>split -l 400000 7368-fulltext.txt</code></p>
   <p class="about_p">This splits into two files of 400,000 lines each, named <code>xaa</code> and <code>xab</code>. We're going to rename these files as <code>FMMWildfires-A.txt</code> and <code>FMMWildfires-B.txt</code>, to keep things straight.</p>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-  <h3 class="about_h3">Running NLTK in Jupyter Notebooks</h3>
+  <h3 class="about_h3" id="4toc">Running NLTK in Jupyter Notebooks</h3>
   <p class="about_p">After installing <%= link_to('Anaconda Navigator', 'https://anaconda.org/anaconda/anaconda-navigator', target: '_blank') %>, we then open the program and choose Jupyter Notebooks from the launch screen. It may be necessary to install Jupyter Notebooks the very first time that you run it.</p>
   <%= image_tag("Tutorial_anaconda.png", alt: "Anaconda Navigator launch screen", class:"body_img")%>
   <p class="about_p">Jupyter notebooks will then display a list of folders on your computer. You might find it helpful to create a new folder with just the text file that you wish to work with. In this example, I have created a folder on my Desktop called "FMMWildfires" that contains two files — the split full-text file.</p>
@@ -57,10 +70,12 @@
   <p class="about_p">Once we hit "Run," we can see the calculated positive, negative, and neutral scores for each sentence that contains the word "evacuation" in our text source. Many of these sentences have been calculated to be neutral, but we do see positive values for sentences where the evacuation was praised, and negative when discussing the destruction of homes and oil rigs. The scores are highlighted with red boxes below, which have been added to the screenshot.</p>
 .  <%= image_tag("Tutorial_anaconda_scores.png", alt: "This last step calculates negative, positive, and neutral scores for each sentence with the keyword in our text file", class:"body_img")%>
   <p class="about_p">Because we have split our very large text file into two parts, we have to repeat the above steps for the FMMWildfires-B.txt file.</p>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
 
-  <h3 class="about_h3">What Can We Learn From Sentiment Analysis?</h3>
+  <h3 class="about_h3" id="5toc">What Can We Learn From Sentiment Analysis?</h3>
   <p class="about_p">Though sentiment analysis can be a powerful tool for quickly determining the emotions expressed through text, there are limitations to what sentiment analysis can provide. Additionally, like all text analysis, we need to be cautious in interpreting the results. For example, sentences that contain profanity have a tendency to be interpreted by NLTK as negative; this can be a problem when using texts from social media, where profanity is often used for emphasis.</p>
   <p class="about_p">Similarly, many negative terms or insults that have been reclaimed by minority groups are flagged as negative when using sentiment analysis. In my own work on queer communities on the early Internet, I see examples of slurs that have been reclaimed by the queer community (indeed, even the word "queer" itself in some cases) being interpreted as negative, despite clearly positive ideas being communicated in the sentence. This can also be a problem when using texts from other parts of the world, where even words in English can mean different things depending on who is writing them.</p>
   <p class="about_p">However, these limitations are similar to other types of computer-mediated text analysis, or even traditional close reading done by human scholars. Overall, the strength of sentiment analysis using NLTK is in the ability to isolate a keyword and provide a quick reading on the positive and negative emotions expressed when using that word. When combined with other text analysis methodologies, sentiment analysis has the ability to allow scholars to really delve into very large text sources.</p>
+  <p class="top_toc"><%=link_to('Back to Top', anchor: '#toc-top') %></p>
  </div>
 <% end %>


### PR DESCRIPTION
This PR adds in a table of contents (toc) for each learning guide. This implementation is a result of feedback from a user survey.

* * *

**GitHub Issues: [259: AUK Documentation - Impliment ToC](https://github.com/archivesunleashed/auk/issues/259)

# What does this Pull Request do?

Work complete includes: 

- code formatting of a table of contents for each learning guide using anchors/links to each H3 section. (Thanks @ruebot for guidance on ruby routing!)
- adds in a "back to top" anchor for each section within the guide to bring back to toc
- updates css file so that toc follows same style and design as rest of site

# How should this be tested?

Has been tested on safari and google chrome locally and renders without issue. 

# Additional Notes:

Please feel free to provide feedback on style and testing :) 

# Interested parties

@ruebot @ianmilligan1 

Thanks in advance for your help with the Archives Unleashed Toolkit!
