### PR TITLE
Add image / screen capture download. #issue-255

### DIFF
--- a/app/assets/javascripts/graphs.js
+++ b/app/assets/javascripts/graphs.js
@@ -273,6 +273,20 @@ $(document).on('turbolinks:load', function () {
     }
   });
 
+  $('#image-link').on('click', function () {
+    var button = document.getElementById('image-link');
+    var canvas = $('.sigma-scene');
+    var img = canvas[1].toDataURL('image/png');
+    button.href = img;
+  });
+
+  $('#modal-image-link').on('click', function () {
+    var button = document.getElementById('modal-image-link');
+    var canvas = $('.sigma-scene');
+    var img = canvas[0].toDataURL('image/png');
+    button.href = img;
+  });
+
   $('span#modal-click').on('click', function () {
     goFullScreen();
   });

--- a/app/assets/javascripts/graphs.js
+++ b/app/assets/javascripts/graphs.js
@@ -276,14 +276,24 @@ $(document).on('turbolinks:load', function () {
   $('#image-link').on('click', function () {
     var button = document.getElementById('image-link');
     var canvas = $('.sigma-scene');
+    var camera = so.camera;
+    var fn = button.getAttribute('download').replace('-image.png', '');
     var img = canvas[1].toDataURL('image/png');
+    button.setAttribute('download', fn + 'xyr-' + Math.abs(Math.round(camera.x))
+      + '-' + Math.abs(Math.round(camera.y)) + '-' + Math.abs(Math.round(camera.ratio))
+      + '-image.png');
     button.href = img;
   });
 
   $('#modal-image-link').on('click', function () {
     var button = document.getElementById('modal-image-link');
     var canvas = $('.sigma-scene');
+    var camera = gm.camera;
+    var fn = button.getAttribute('download').replace('-image.png', '');
     var img = canvas[0].toDataURL('image/png');
+    button.setAttribute('download', fn + 'xyr-' + Math.abs(Math.round(camera.x))
+      + '-' + Math.abs(Math.round(camera.y)) + '-' + Math.abs(Math.round(camera.ratio))
+      + '-image.png');
     button.href = img;
   });
 

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -28,6 +28,9 @@
           <button type="button" id="modal-scale-down" class="scale-down" data-toggle="tooltip" title="Scale down node sizes." disabled>
             <span class="fa fa-level-down"></span>
           </button>
+          <a href="#" id="modal-image-link" download="<%= @collection.id %>-image.png"><button type="button" id="modal-image" class="graph-image" data-toggle="tooltip" title="Download a screen shot.">
+            <span class="fa fa-image"></span>
+          </button></a>
           <div id="graph-modal"></div>
         </div>
       </div>
@@ -62,6 +65,9 @@
           <button type="button" id="scale-down" class="scale-down" data-toggle="tooltip" data-placement="top" title="Scale down node sizes." disabled>
             <span class="fa fa-level-down"></span>
           </button>
+          <a href="#" id="image-link" download="<%= @collection.id %>-image.png"><button type="button" id="modal-image" class="graph-image" data-toggle="tooltip" title="Download a screen shot.">
+            <span class="fa fa-image"></span>
+          </button></a>
           <div id="graph"></div>
         </div>
         <%= javascript_tag do %>


### PR DESCRIPTION
Add a button to the graph to screen capture the canvas and save it to a file `{collection_id}-image.png`

**GitHub issue(s)**:

#255

# What does this Pull Request do?

Clicking the button that looks like this:

![image](https://user-images.githubusercontent.com/111091/53360215-f84ca080-3902-11e9-9632-1c63e11069e1.png)

Will produce an image for a canvas like this:

![image](https://user-images.githubusercontent.com/111091/53360251-0ac6da00-3903-11e9-9e2b-892f83c2c301.png)

and download a file called `{collection-id}-image.png` that looks like this.

![image](https://user-images.githubusercontent.com/111091/53360308-32b63d80-3903-11e9-93cd-614a4270f168.png)

And if you do some toggling and/or zooming in the screen, the changes will be preserved in the image:

![image](https://user-images.githubusercontent.com/111091/53360366-6002eb80-3903-11e9-958e-50831584d829.png)


# How should this be tested?

* Run auk
* Enter collection screen, click image icon.
* View image.

# Additional Notes:

There are some UI considerations here before merge I think, but overall I think this works approximately the way it should.

# Interested parties

@ianmilligan1 @SamFritz @ruebot 

Thanks in advance for your help with the Archives Unleashed Toolkit!
