### PR TITLE
Better Highlights Need for Archive-It Credentials, Resolves #293

### DIFF
--- a/app/views/pages/about.html.erb
+++ b/app/views/pages/about.html.erb
@@ -8,6 +8,7 @@
   <h3 class=about_h3>Project Overview</h3>
     <p class="about_p">The Archives Unleashed Cloud is an open source cloud-based analysis tool that helps researchers and scholars conduct web archive analysis.</p>
     <p class="about_p">The Cloud is a component of the <%= link_to('Archives Unleashed Project', 'https://archivesunleashed.org', target: '_blank') %>, which aims to allow researchers, scholars, librarians and archivists the ability to access and investigate their web archival collections. As accessibility is a main priority of the project, the Cloud supports this goal by providing a web-based front end for users to access the <%= link_to('most-recent version', 'https://github.com/archivesunleashed/aut/releases', target: '_blank') %> of the <%= link_to('Archives Unleashed Toolkit', 'https://archivesunleashed.org/aut/', target: '_blank') %>.
+    <p class="about_p">While we are exploring integration with other services in the future, the Cloud currently requires <%= link_to('Archive-It', 'https://archive-it.org', target: '_blank') %> credentials to use.</p>
 
   <h3 class=about_h3>What is Web Archiving, what are WARCS, and why should I care?</h3>
     <p class="about_p"><strong>Web archiving</strong> is the process of preserving born-digital content on the World Wide Web. Thinking about how curated content is organized, there are two main components:</p>

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,4 +1,10 @@
 <% cache do %>
+<div class="alert alert-warning alert-dismissible fade show" role="alert">
+  <strong>New user?</strong> You currently need Archive-It credentials to use our service. Please read our <%= link_to('FAQ', '/faq', target: '_blank') %>.
+  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+    <span aria-hidden="true">&times;</span>
+  </button>
+</div>
 <div class="container-fluid">
   <div class="carousel slide" data-ride="carousel">
     <div class="carousel-inner">

--- a/app/views/pages/home.html.erb
+++ b/app/views/pages/home.html.erb
@@ -1,6 +1,6 @@
 <% cache do %>
 <div class="alert alert-warning alert-dismissible fade show" role="alert">
-  <strong>New user?</strong> You currently need Archive-It credentials to use our service. Please read our <%= link_to('FAQ', '/faq', target: '_blank') %>.
+  <strong>New user?</strong> You currently need <%= link_to('Archive-It', 'https://archive-it.org', target: '_blank') %> credentials to use our service. Please read our <%= link_to('FAQ', '/faq', target: '_blank') %>.
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
     <span aria-hidden="true">&times;</span>
   </button>


### PR DESCRIPTION
**GitHub issue(s)**:

#293 

# What does this Pull Request do?

In #293, we noted that we needed to highlight the need for an Archive-It account to use the Cloud. While that may change down the road, right now we have a lot of folks who sign up for the Cloud but then realize they need an Archive-It account and are a bit confused or disappointed.

This PR does two main things:
- adds a warning bar on the main page, laying out the situation for new users and asking them to read the FAQ;
- Notes the Archive-It connection explicitly in the "Project Overview" section of the "about" page. While that information is available if you scroll down the page, this hopefully does a better job of highlighting this. The FAQ already makes the situation clear up front.

# How should this be tested?

TravisCI should turn green. Please review for language suggestions and aesthetic appeal. 

# Screenshots:

Screenshots added for convenience.

Here's the new home page:
<img width="1195" alt="Screen Shot 2019-05-09 at 10 42 16 AM" src="https://user-images.githubusercontent.com/3834704/57487962-dadf6f80-727f-11e9-9fd3-b002e919535f.png">

And here's the added content to the "about" page (red arrow is my screenshot annotation):
<img width="1195" alt="Screen Shot 2019-05-09 at 11 17 24 AM" src="https://user-images.githubusercontent.com/3834704/57487990-dd41c980-727f-11e9-87d3-731915cf400c.png">


# Interested parties

@ruebot @SamFritz 