### PR TITLE
Updating Archive-It Transition Message and Warning Header

### DIFF
--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -27,7 +27,7 @@
   </span>
 </nav>
 <div class="alert alert-danger alert-dismissible fade show" role="alert">
-  <strong>The Cloud will be shutting down on 30 June 2021 and migrating to Archive-It.</strong> Learn more about the transition <%= link_to('here', '/archiveit', target: '_blank') %>. 
+  <strong>The Cloud will be shutting down on 30 June 2021 and migrating to Archive-It.</strong> No new jobs will be run after 31 May 2021. Learn more about the transition <%= link_to('here', '/archiveit', target: '_blank') %>. 
   <button type="button" class="close" data-dismiss="alert" aria-label="Close">
     <span aria-hidden="true">&times;</span>
   </button>

--- a/app/views/pages/archiveit.html.erb
+++ b/app/views/pages/archiveit.html.erb
@@ -10,11 +10,15 @@
     <p class="about_p">As you already had to be an Archive-It subscriber to use the Archives Unleashed Cloud, we hope this won't prove too disruptive. Similar functionality to the Cloud will be available through a new "Datasets" tab there, replacing the existing <%= link_to('Archive-It Research Services', 'https://support.archive-it.org/hc/en-us/articles/209671666-Introduction-to-Archive-It-Research-Services-ARS-', target: '_blank') %> offerings.</p>
     <p class="about_p">For more details, you can always subscribe to our <%= link_to('project newsletter', 'http://eepurl.com/dfpU7j', target: '_blank') %> or follow our <%= link_to('project blog', 'https://news.archivesunleashed.org', target: '_blank') %>. We're excited about this next stage!</p>
 
+  <h3 class=about_h3>When will I be able to use the Cloud until?</h3>
+    <p class="about_p"><strong>Starting May 31, 2021, users will no longer be able to run jobs on the Archives Unleashed Cloud.</strong> If there are any collections you wish to analyze using the Archives Unleashed Cloud, please be sure to do so before this date. Any jobs entering the queue before May 31st will be processed. Though, if a job is triggered from a multi-terabyte collection, we cannot guarantee its completion.</p>
+    <p class="about_p">On <strong>30 June 2021</strong>, we will delete the Cloud, including all of your derivative files and user data.
   <h3 class=about_h3>What do I need to do? What will happen to my data after 30 June 2021?</h3>
-    <p class="about_p">On 30 June 2021, we will delete the Cloud, including all of your derivative files and user data. <strong>If you want to keep a copy of your derivative datasets</strong>, we encourage you to download them before the Cloud shuts down.</p>
+    <p class="about_p">If you want to keep a copy of your derivative datasets, we encourage you to download them before the Cloud shuts down.</p>
     <p class="about_p">As our project has not routinely stored ARC or WARC files beyond the time needed to process them into derivative files, you do not need to worry about any of your data remaining.</p>
+    <p class="about_p">If you are an existing user, please check your email! We are working with Archive-It to provide early access to the Archive-It Research Services Cloud. As our roll-out plans emerge, we will be in touch with more details in June/July 2021. Stay tuned.</p>
 
-    <h3 class=about_h3>I have questions! Who can I contact?</h3>
+  <h3 class=about_h3>I have questions! Who can I contact?</h3>
     <p class="about_p">We would love to hear from you. You can always join our <%= link_to('Slack team', 'http://slack.archivesunleashed.org', target: '_blank') %> if you want to chat about the project today and in the future. You can also follow us on <%= link_to('Twitter', 'https://twitter.com/unleasharchives', target: '_blank') %>!</p>
     <p class="about_p">Alternatively, please connect with us via e-mail at <%= link_to('sam.fritz@archivesunleashed.org', 'mailto:sam.fritz@archivesunleashed.org', target: '_blank') %>.</p>
 


### PR DESCRIPTION
# What does this Pull Request do?

This pull request updates the transition note + header to better align with the note that we are sending out to AUK users on 4 May 2021. It includes:

- Note about the end of processing new jobs on 31 May 2021
- Note about "check your emails for more details"
- Makes this clear in the warning header as well

# How should this be tested?

@SamFritz and @ruebot to review text. 

# Additional Notes:

I am going to miss the Cloud. ☹️ 